### PR TITLE
Remove Cron from calendar list

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ Apps on this list are:
 
 ## Calendar & Time
 
-- [Cron](https://cron.com/) - Next-gen calendar for professionals. `Free`
 - [Fantastical](https://flexibits.com/fantastical) - Calendar app with natural language input. `Subscription`
 - [Itsycal](https://www.mowglii.com/itsycal/) - Tiny menu bar calendar. `Free` `Open Source`
 - [Meeting Bar](https://github.com/leits/MeetingBar) - Menu bar app for your calendar meetings. `Free` `Open Source`


### PR DESCRIPTION
## Description

Removed Cron from the calendar section.

It was never native but it also no longer exists. It was bought by Notion years ago and rebranded as Notion Calendar.

## Type of Change

- [ ] Add new app
- [x] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## Additional Notes

<!-- Any other information that might be helpful -->