### PR TITLE
Add MirrorMask to Security & Privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Apps on this list are:
 - [Little Snitch](https://www.obdev.at/products/littlesnitch/) - Network monitor and firewall. `Paid`
 - [Lulu](https://objective-see.org/products/lulu.html) - Open-source firewall for macOS. `Free` `Open Source`
 - [Micro Snitch](https://www.obdev.at/products/microsnitch/) - Monitor camera and microphone access. `Paid`
+- [MirrorMask](https://mirrormask.app) - Reveal and reshape your algorithmic identity across Google, Facebook, Reddit, and more. `Freemium`
 - [OverSight](https://objective-see.org/products/oversight.html) - Monitor mic and webcam access. `Free` `Open Source`
 
 ## System Utilities


### PR DESCRIPTION
## Summary

Adding [MirrorMask](https://mirrormask.app) to the Security & Privacy section.

- **Built with**: Swift, SwiftUI, macOS 14+
- **What it does**: Reveals the interest profile platforms have built about you and reshapes it by browsing as a different persona across Google, YouTube, Facebook, Reddit, Amazon, and Temu
- **Pricing**: Freemium (5-day full trial, then $39 one-time)
- **100% local**: No cloud, no accounts, all data stays on your machine