### PR TITLE
Add Command Book app to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Apps on this list are:
 ## Developer Tools
 
 - [CodeEdit](https://github.com/CodeEditApp/CodeEdit) - Native code editor for macOS. `Free` `Open Source`
+- [Command Book](https://commandbookapp.com) - A terminal companion for long-running terminal commands. `Freemium`
 - [DevCleaner](https://github.com/vashpan/xcode-dev-cleaner) - Clean Xcode cache and derived data. `Free` `Open Source`
 - [DevToys](https://devtoys.app/) - Swiss Army knife for developers. `Free` `Open Source`
 - [DevUtils](https://devutils.com/) - All-in-one offline toolbox for developers (42+ tools). `Freemium`


### PR DESCRIPTION
## Description

Add Command Book app to Developer Tools.

## Type of Change

- [X] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:**  Command Book
**Category:**   Developer Tools
**Website:**  https://commandbookapp.com
**Pricing:**  Free personal version. Paid pro version with more features.

## Checklist

- [X] My app follows the formatting guidelines
- [X] I've added the app in alphabetical order
- [X] The app is truly native (not Electron/web wrapper)
- [X] Links are working
- [X] Description is concise (< 100 characters)
- [X] Pricing label is accurate
- [X] I've read the CONTRIBUTING.md
- [X] App is actively maintained
- [X] No duplicate entry

## Additional Notes

Command Book is a native Swift/Swift UI app to help developers run and manage commands that traditionally have been run in the terminal.

Thank you!