### PR TITLE
Add Pommy: Focus Timer to Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Apps on this list are:
 - [Itsycal](https://www.mowglii.com/itsycal/) - Tiny menu bar calendar. `Free` `Open Source`
 - [MenubarX](https://menubarx.app/) - Browser in your menu bar. `Freemium`
 - [One Thing](https://sindresorhus.com/one-thing) - Put a single task in your menu bar. `Paid`
+- [Pommy: Focus Timer](https://apps.apple.com/pt/app/pommy-focus-timer/id6747729586) - Lightweight, native Pomodoro timer with iCloud sync. `Freemium`
 
 ## Network Tools
 


### PR DESCRIPTION
## Description

Adds Pommy, a native SwiftUI/AppKit menu bar Pomodoro timer that follows macOS Human Interface Guidelines.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** Pommy: Focus Timer
**Category:** Menu Bar Apps
**Website:** https://apps.apple.com/pt/app/pommy-focus-timer/id6747729586
**Pricing:** Freemium

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry