### PR TITLE
Add Sleepr to Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [MenubarX](https://menubarx.app/) - Browser in your menu bar. `Freemium`
 - [One Thing](https://sindresorhus.com/one-thing) - Put a single task in your menu bar. `Paid`
 - [SaneBar](https://sanebar.com) - Privacy-first menu bar manager. Hide and organize icons. `Freemium`
+- [Sleepr](https://sleepr.app/) - The missing timer to put your Mac to sleep. `Paid`
 - [Thaw](https://github.com/stonerl/Thaw) - Powerful menu bar management tool. Fork of Ice, lower resource usage. `Free` `Open Source`
 - [TickerPad](https://tickerpad.app) - Real-time crypto prices in your macOS menu bar.  `Freemium`
 


### PR DESCRIPTION
Sleepr as paid app, pure native.
It re-adds the sleep timer removed from macOS years ago.

## Description

<!-- Describe your changes -->
Add Sleepr app (v2, v3 is coming). It re-add the removed sleep timer to macOS.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:**  Sleepr
**Category:**  Menu Bar App
**Website:**  https://sleepr.app/
**Pricing:**  $4.99

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

<!-- Any other information that might be helpful -->