### PR TITLE
Add Lockpaw to Security & Privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Cryptomator](https://cryptomator.org/) - Multi-platform client-side encryption. `Free` `Open Source` `EU`
 - [KnockKnock](https://objective-see.org/products/knockknock.html) - See what's persistently installed on your Mac. `Free` `Open Source`
 - [Little Snitch](https://www.obdev.at/products/littlesnitch/) - Network monitor and firewall. `Paid` `EU`
+- [Lockpaw](https://github.com/sorkila/lockpaw) - Lock the screen while background tasks, builds, and AI agents keep running. `Free` `Open Source`
 - [Lulu](https://objective-see.org/products/lulu.html) - Open-source firewall for macOS. `Free` `Open Source`
 - [Micro Snitch](https://www.obdev.at/products/microsnitch/) - Monitor camera and microphone access. `Paid` `EU`
 - [OverSight](https://objective-see.org/products/oversight.html) - Monitor mic and webcam access. `Free` `Open Source`


### PR DESCRIPTION
## Summary

- Adds [Lockpaw](https://github.com/sorkila/lockpaw) to the **Security & Privacy** category
- Lockpaw is a native Swift/SwiftUI macOS menu bar app that locks the screen while letting background tasks, builds, and AI agents keep running
- Free and open source
- Website: https://getlockpaw.com

## Checklist

- [x] App is truly native (Swift/SwiftUI)
- [x] App is in the correct category (Security & Privacy)
- [x] Alphabetically ordered within category
- [x] Follows formatting guidelines exactly
- [x] Description is concise and objective
- [x] Link works and points to official repo
- [x] Pricing label is accurate (`Free` `Open Source`)
- [x] No duplicate entries
- [x] Commit message is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)