### PR TITLE
Add Revu - local-first macOS spaced repetition app

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Keyboard Maestro](https://www.keyboardmaestro.com/) - Automate applications and websites. `Paid`
 - [OmniFocus](https://www.omnigroup.com/omnifocus/) - Professional-grade task management. `Paid`
 - [Raycast](https://www.raycast.com/) - Blazingly fast extendable launcher. `Freemium`
+- [Revu](https://revu.cards) - Local-first spaced repetition app with FSRS scheduling, Anki import, and study guides. `Free` `Open Source`
 - [SelfControl](https://selfcontrolapp.com/) - Block distracting websites. `Free` `Open Source`
 - [TaskPaper](https://www.taskpaper.com/) - Plain text to-do lists. `Paid`
 - [Things](https://culturedcode.com/things/) - Award-winning task manager. `Paid`


### PR DESCRIPTION
## App Details

- **Name:** Revu
- **Website:** https://revu.cards
- **Repository:** https://github.com/JuliusBrussee/revu-swift
- **Category:** Productivity
- **Pricing:** Free, Open Source (GPL-3.0)

## Why Revu belongs on this list

Revu is a **100% native macOS app** built with **Swift 6 and SwiftUI** -- no Electron, no web wrappers, no cross-platform frameworks. It is a local-first spaced repetition app featuring FSRS scheduling, Anki import, study guides, exams, and forecasting, all with a Notion-inspired UI.

## Checklist

- [x] App is truly native (Swift/SwiftUI) -- not Electron or a web wrapper
- [x] App is in the correct category (Productivity)
- [x] Alphabetically ordered within category
- [x] Follows formatting guidelines
- [x] Description is concise and objective
- [x] Link works and points to official site
- [x] Pricing label is accurate (`Free` `Open Source`)
- [x] No duplicate entries
- [x] Commit message is clear