### PR TITLE
Add Typer - free local AI chat for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Things](https://culturedcode.com/things/) - Award-winning task manager. `Paid`
 - [Tot](https://tot.rocks/) - Elegant text collection on menu bar. `Freemium`
 - [Speakmac](https://www.speakmac.app/) - Offline hotkey dictation for macOS that types into any app using on-device transcription. `One-Time Subscription`
+- [Typer](https://typer.space) - Free local AI chat for macOS. Runs entirely on-device — no account, no cloud, no ads. Works offline. Apple Silicon required. `Free`
 
 ## Screenshot & Recording
 


### PR DESCRIPTION
## Description

Adds Typer to the **Productivity** category — a free local AI chat app for macOS (Apple Silicon) built with Tauri + Rust. Runs AI models entirely on-device with no account, no cloud, no ads, works fully offline.

**Note on tech stack:** Typer is built with Tauri + Rust (not Swift/SwiftUI). On macOS, Tauri uses the native WKWebView rather than a bundled Chromium engine (unlike Electron), making it lightweight and resource-efficient. Whether this qualifies as "native" by this list's criteria is for the maintainer to decide — raising it transparently here.

## Type of Change

- [x] Add new app

## App Details (if adding new app)

**App Name:** Typer
**Category:** Productivity
**Website:** https://typer.space
**Pricing:** Free

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [ ] The app is truly native (not Electron/web wrapper) — *see note above: Tauri/WKWebView, not Electron. Flagging for maintainer judgment.*
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate (Free)
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

Built with Tauri v2 + Rust + Metal (Apple Silicon GPU). Distributed via Mac App Store: https://apps.apple.com/app/typer-ai/id6751274483. Submitter is affiliated with the product.