### PR TITLE
Add Shake It On to Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [MenubarX](https://menubarx.app/) - Browser in your menu bar. `Freemium`
 - [One Thing](https://sindresorhus.com/one-thing) - Put a single task in your menu bar. `Paid`
 - [SaneBar](https://sanebar.com) - Privacy-first menu bar manager. Hide and organize icons. `Freemium`
+- [Shake It On](https://shakeiton.app?ref=awesome-native-mac) - Keep your Mac awake with organic mouse movement and smart conditions. `Paid`
 - [Thaw](https://github.com/stonerl/Thaw) - Powerful menu bar management tool. Fork of Ice, lower resource usage. `Free` `Open Source`
 - [TickerPad](https://tickerpad.app) - Real-time crypto prices in your macOS menu bar.  `Freemium`
 


### PR DESCRIPTION
Adding [Shake It On](https://shakeiton.app) to the Menu Bar Apps section.

**Shake It On** is a native SwiftUI macOS menu bar app (macOS 14+) that keeps your Mac awake by generating organic mouse movement. Built with Swift/SwiftUI and AppKit — no Electron, no web views.

**Features:**
- Smart activation conditions: CPU usage, running apps, Wi-Fi network, external display, audio playing
- Smart pause triggers: battery mode, camera in use, Focus/DND, screen locked
- Works with corporate MDM and remote desktop
- $9.99 one-time, no subscription