### PR TITLE
Add AI Dictation to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 ## Productivity
 
+- [AI Dictation](https://aidictation.com/) - Speech-to-text for Mac with auto-switching offline/online recognition; AI removes filler words, fixes grammar, and formats text per app. `Freemium`
 - [Alfred](https://www.alfredapp.com/) - Productivity app for macOS with powerful workflows. `Freemium`
 - [BetterTouchTool](https://folivora.ai/) - Customize input devices on your Mac. `Paid` `EU`
 - [Due](https://www.dueapp.com/) - Reminders with persistent alerts. `Paid`


### PR DESCRIPTION
Adds [AI Dictation](https://aidictation.com/) — native macOS speech-to-text that auto-switches between offline and online engines, with AI cleanup that removes filler words, fixes grammar, and formats text per app.

- Native macOS app (no Electron)
- Free tier: 2,000 words/month, no account required
- Pro: $8.49/mo or $199.99 lifetime
- Inserted alphabetically before Alfred in the Productivity section