### PR TITLE
Add SSH Keys Manager to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Paw](https://paw.cloud/) - Advanced API tool for Mac. `Paid`
 - [Proxyman](https://proxyman.io/) - Native HTTP debugging proxy. `Freemium`
 - [RocketSim](https://www.rocketsim.app/) - Enhance Xcode Simulator productivity. `Freemium`
+- [SSH Keys Manager](https://github.com/Stmol/ssh-keys-manager-macos-app) - Native macOS app for managing SSH keys and SSH config entries. `Free` `Open Source`
 - [SF Symbols](https://developer.apple.com/sf-symbols/) - Browse and export Apple's SF Symbols. `Free`
 
 ## Email & Communication


### PR DESCRIPTION
## Summary
- add SSH Keys Manager to the Developer Tools category
- keep alphabetical order within the category
- use the official GitHub repository link and pricing labels

## Notes
- native macOS app built with SwiftUI
- active repository with tagged releases
- description follows the list formatting guidelines