### PR TITLE
Add Spokenly to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Raycast](https://www.raycast.com/) - Blazingly fast extendable launcher. `Freemium`
 - [Revu](https://revu.cards) - Local-first spaced repetition app with FSRS scheduling, Anki import, and study guides. `Free` `Open Source`
 - [SelfControl](https://selfcontrolapp.com/) - Block distracting websites. `Free` `Open Source`
+- [Spokenly](https://spokenly.app/) - Dictation for macOS with free on-device models and free cloud transcription via your own API keys. `Freemium`
 - [TaskPaper](https://www.taskpaper.com/) - Plain text to-do lists. `Paid`
 - [Things](https://culturedcode.com/things/) - Award-winning task manager. `Paid`
 - [Tot](https://tot.rocks/) - Elegant text collection on menu bar. `Freemium`


### PR DESCRIPTION
## Description

Spokenly is a native macOS dictation app built with Swift/SwiftUI. It offers free on-device transcription (Apple Speech, Parakeet CoreML) and free cloud transcription via the user's own API keys (OpenAI, Deepgram, Soniox, Fireworks, Cartesia). Lightweight (~21MB) and follows macOS HIG.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** Spokenly
**Category:** Productivity
**Website:** https://spokenly.app/
**Pricing:** Freemium

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry