### PR TITLE
Add My Keepass to Password Managers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 ## Password Managers
 
+- [My Keepass](https://apps.apple.com/us/app/my-keepass-menubar-passwords/id1553185112?mt=12) - Access your KeepPass passwords easily from the menu bar. `Paid`
 - [Strongbox](https://strongboxsafe.com/) - Native KeePass client for macOS. `Freemium`
 
 ## PDF Tools


### PR DESCRIPTION
## Description

Added My Keepass to Password Managers section.

## Type of Change

- [X] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:**  My Keepass
**Category:**  Productivity
**Website:**  https://apps.apple.com/us/app/my-keepass-menubar-passwords/id1553185112?mt=12
**Pricing:**  $4.99

## Checklist

- [X] My app follows the formatting guidelines
- [X] I've added the app in alphabetical order
- [X] The app is truly native (not Electron/web wrapper)
- [X] Links are working
- [X] Description is concise (< 100 characters)
- [X] Pricing label is accurate
- [X] I've read the CONTRIBUTING.md
- [X] App is actively maintained
- [X] No duplicate entry

## Additional Notes

None