### PR TITLE
Add TablePro to Database Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 - [Postico](https://eggerapps.at/postico2/) - Modern PostgreSQL client for macOS. `Paid` `EU`
 - [TablePlus](https://tableplus.com/) - Modern native database management tool. `Freemium`
+- [TablePro](https://tablepro.app) - Native database client for MySQL, PostgreSQL, SQLite, MongoDB, Redis, and more. `Free` `Open Source`
 
 ## Design Tools
 


### PR DESCRIPTION
## Summary

Adds [TablePro](https://tablepro.app) to the Database Tools category.

TablePro is a free, open-source, native macOS database client built with SwiftUI and AppKit. It connects to MySQL, PostgreSQL, SQLite, MongoDB, Redis, and 15+ more databases using native drivers (no JDBC, no Electron). Source: https://github.com/TableProApp/TablePro (AGPL-3.0).

Disclosure: I am the author of TablePro.

## Checklist

- [x] App is truly native (Swift / SwiftUI / AppKit, no Electron)
- [x] App is in the correct category (Database Tools)
- [x] Alphabetically ordered within category (after TablePlus)
- [x] Follows formatting guidelines exactly
- [x] Description is concise and objective (under 100 chars)
- [x] Link works and points to official site
- [x] Pricing label is accurate (`Free` `Open Source`)
- [x] No duplicate entries
- [x] Commit message is clear