### PR TITLE
Add Writer to Markdown Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Marked 2](https://marked2app.com/) - Markdown preview and conversion. `Paid`
 - [MWeb](https://www.mweb.im/) - Pro Markdown writing and note-taking. `Paid`
 - [Typora](https://typora.io/) - Minimal Markdown editor and reader. `Paid`
+- [Writer](https://writer.computer/) - Local-first markdown editor with a Rust backend and native WKWebView. `Free` `Open Source`
 
 ## Menu Bar Apps
 


### PR DESCRIPTION
Adds [Writer](https://writer.computer/) to the Markdown Editors section.

**About Writer**
- Local-first markdown editor for plain-text workflows (Obsidian vaults, docs repos, personal wikis).
- Rust backend (Tauri v2) with native WKWebView — not Electron, no bundled Chromium.
- Open source (GPL-3), signed and notarized macOS build.
- Repo: https://github.com/joelbqz/writer-computer

**Disclosure**
Writer uses Tauri, so the UI layer renders in WKWebView rather than pure SwiftUI/AppKit. CONTRIBUTING.md notes apps "may use native web views (WebKit) for specific features," and Writer's footprint is closer to a native app than to Electron — but happy to defer if maintainers consider this out of scope for the list.

**Checklist**
- [x] Added in alphabetical order within the section
- [x] Format: `[App Name](link) - Brief description.` with pricing label
- [x] Actively maintained
- [x] Available for download