### PR TITLE
Add OpenQuack to Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Itsyhome](https://github.com/nickustinov/itsyhome-macos) - Smart home meets menu bar. `Freemium` `Open Source`
 - [MenubarX](https://menubarx.app/) - Browser in your menu bar. `Freemium`
 - [One Thing](https://sindresorhus.com/one-thing) - Put a single task in your menu bar. `Paid`
+- [OpenQuack](https://github.com/larryxiao/openquack) - Transcribes a 5-minute clip in 2.8 s — local WhisperKit dictation, noise-robust. ~8 MB native Swift. `Free` `Open Source`
 - [SaneBar](https://sanebar.com) - Privacy-first menu bar manager. Hide and organize icons. `Freemium`
 - [Thaw](https://github.com/stonerl/Thaw) - Powerful menu bar management tool. Fork of Ice, lower resource usage. `Free` `Open Source`
 - [TickerPad](https://tickerpad.app) - Real-time crypto prices in your macOS menu bar.  `Freemium`


### PR DESCRIPTION
Adds [OpenQuack](https://github.com/larryxiao/openquack) to the **Menu Bar Apps** section.

- Native Swift, ~8 MB — no Electron, matches this list's thesis exactly
- MIT license, actively maintained
- Alphabetical insert between One Thing and SaneBar

OpenQuack is a local WhisperKit dictation app: press hotkey, speak, release — transcript appears at cursor. Transcribes a 5-minute clip in 2.8 s, noise-robust, no telemetry.