### PR TITLE
Add AI Memory Reader to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 ## Developer Tools
 
+- [AI Memory Reader](https://github.com/nvwalj/ai-memory-reader) - Native macOS/iOS viewer for AI agent memory files (CLAUDE.md, AGENTS.md, GEMINI.md). Markdown rendering, file watching, JSON viewer for Claude Code session telemetry. `Free` `Open Source`
 - [BucketMate](https://bucketmate.app/) - Native S3 GUI Client for macOS `Freemium`
 - [CodeEdit](https://github.com/CodeEditApp/CodeEdit) - Native code editor for macOS. `Free` `Open Source`
 - [DevCleaner](https://github.com/vashpan/xcode-dev-cleaner) - Clean Xcode cache and derived data. `Free` `Open Source`


### PR DESCRIPTION
## App: AI Memory Reader

**Repo:** https://github.com/nvwalj/ai-memory-reader
**Site:** https://nvwalj.github.io/ai-memory-reader/

### Why it fits the list

- **Native** — SwiftUI + AppKit, no Electron / no web view (uses native `NSTextView` for the editor and `MarkdownUI` for rendering)
- **Lightweight** — 3 MB universal binary (arm64 + x86_64)
- **Follows HIG** — NavigationSplitView sidebar, GitHub-style markdown, system theme awareness, ⌘O/⌘S/⌘E/⌘F shortcuts
- **Actively maintained** — v0.4.2 shipped today (2026-05-17)

### What it does

Browses the `CLAUDE.md`, `AGENTS.md`, `GEMINI.md` files that AI coding agents create across the home directory. Auto-detects Claude Code, Codex, Cursor, Gemini, Continue, GitHub Copilot, Aider, and OpenClaw memory locations. Also pretty-prints Claude Code's `~/.claude/projects/*.json` session telemetry (NDJSON, chunked rendering).

### License

GPL-3.0