### PR TITLE
Add Stargazer Bar to Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [One Thing](https://sindresorhus.com/one-thing) - Put a single task in your menu bar. `Paid`
 - [OpenQuack](https://github.com/larryxiao/openquack) - Transcribes a 5-minute clip in 2.8 s — local WhisperKit dictation, noise-robust. ~8 MB native Swift. `Free` `Open Source`
 - [SaneBar](https://sanebar.com) - Privacy-first menu bar manager. Hide and organize icons. `Freemium`
+- [Stargazer Bar](https://jazzyalex.github.io/stargazer-bar/) - Track one public GitHub repo's stars and release downloads from your menu bar. `Free` `Open Source`
 - [Thaw](https://github.com/stonerl/Thaw) - Powerful menu bar management tool. Fork of Ice, lower resource usage. `Free` `Open Source`
 - [TickerPad](https://tickerpad.app) - Real-time crypto prices in your macOS menu bar.  `Freemium`
 


### PR DESCRIPTION
Adds Stargazer Bar, an open-source native macOS menu bar app for tracking one public GitHub repo's stars and release downloads.

Checklist:
- Native macOS app built with Swift/AppKit/SwiftUI
- Open source
- Actively maintained
- Downloadable via GitHub release and Homebrew cask
- Not Electron or a web wrapper