### PR TITLE
Add MD Preview to Markdown Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [iA Writer](https://ia.net/writer) - Focused writing app with beautiful typography. `Paid`
 - [MacDown](https://macdown.uranusjr.com/) - Open source Markdown editor for macOS. `Free` `Open Source`
 - [Marked 2](https://marked2app.com/) - Markdown preview and conversion. `Paid`
+- [MD Preview](https://vorojar.github.io/md-preview/) - Lightweight Markdown preview app using Rust and native WebView. `Free` `Open Source`
 - [MWeb](https://www.mweb.im/) - Pro Markdown writing and note-taking. `Paid`
 - [Typora](https://typora.io/) - Minimal Markdown editor and reader. `Paid`
 - [Writer](https://writer.computer/) - Local-first markdown editor with a Rust backend and native WKWebView. `Free` `Open Source`


### PR DESCRIPTION
## Description

Add MD Preview to the Markdown Editors section. This is a maintainer submission, but I believe it fits this list's native/no-Electron criteria: MD Preview is built with Rust and the system WebView, uses no Electron or bundled Chromium, and ships a signed/notarized macOS universal DMG.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** MD Preview  
**Category:** Markdown Editors  
**Website:** https://vorojar.github.io/md-preview/  
**Pricing:** Free, Open Source  

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

Project repo: https://github.com/vorojar/md-preview
Latest release: https://github.com/vorojar/md-preview/releases/tag/v1.1.3
