### PR TITLE
Add Glance to Markdown Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 ## Markdown Editors
 
+- [Glance](https://glance.md/) - Native Markdown viewer and Quick Look extension. `Free`
 - [iA Writer](https://ia.net/writer) - Focused writing app with beautiful typography. `Paid`
 - [MacDown](https://macdown.uranusjr.com/) - Open source Markdown editor for macOS. `Free` `Open Source`
 - [Marked 2](https://marked2app.com/) - Markdown preview and conversion. `Paid`


### PR DESCRIPTION
## Summary
Adds [Glance](https://glance.md/) — a native macOS Markdown viewer with a bundled Quick Look extension.

- Swift/SwiftUI, ~8 MB, offline, no telemetry
- Renders tables, syntax-highlighted code, Mermaid, and LaTeX in Finder Quick Look
- Free, Developer ID signed and notarized

## Checklist
- [x] Native macOS app (Swift/SwiftUI)
- [x] Actively maintained
- [x] One-line description, alphabetical placement in Markdown Editors

Made with [Cursor](https://cursor.com)