### PR TITLE
Add Glance

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 ## Markdown Editors
 
+- [Glance](https://glance.md/) - Native Markdown viewer and Quick Look extension. `Free`
 - [iA Writer](https://ia.net/writer) - Focused writing app with beautiful typography. `Paid`
 - [MacDown](https://macdown.uranusjr.com/) - Open source Markdown editor for macOS. `Free` `Open Source`
 - [Marked 2](https://marked2app.com/) - Markdown preview and conversion. `Paid`


### PR DESCRIPTION
Adds Glance (https://glance.md/) — native Markdown viewer and Quick Look extension for macOS.