### PR TITLE
Add Markup (Markdown Editors)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [iA Writer](https://ia.net/writer) - Focused writing app with beautiful typography. `Paid`
 - [MacDown](https://macdown.uranusjr.com/) - Open source Markdown editor for macOS. `Free` `Open Source`
 - [Marked 2](https://marked2app.com/) - Markdown preview and conversion. `Paid`
+- [Markup](https://github.com/oratis/Markup) - Reader-first markdown editor with a Rust backend and native WKWebView; vault, backlinks and full-text search. `Free` `Open Source`
 - [MWeb](https://www.mweb.im/) - Pro Markdown writing and note-taking. `Paid`
 - [Typora](https://typora.io/) - Minimal Markdown editor and reader. `Paid`
 - [Writer](https://writer.computer/) - Local-first markdown editor with a Rust backend and native WKWebView. `Free` `Open Source`


### PR DESCRIPTION
Adds **Markup** to **Markdown Editors**.

- **Repo:** https://github.com/oratis/Markup
- Free, open-source (MIT) macOS Markdown editor with a **Rust backend and native WKWebView** (same architecture as the existing `Writer` entry). Reader-first: renders `.md` like a clean web page and edits on demand; local vault with wikilinks/backlinks/graph and full-text search. No accounts, no telemetry.

Placed alphabetically between Marked 2 and MWeb, with `Free` `Open Source` badges.