### PR TITLE
Add Rockxy to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Paw](https://paw.cloud/) - Advanced API tool for Mac. `Paid`
 - [Proxyman](https://proxyman.io/) - Native HTTP debugging proxy. `Freemium`
 - [RocketSim](https://www.rocketsim.app/) - Enhance Xcode Simulator productivity. `Freemium`
+- [Rockxy](https://rockxy.io) - macOS HTTP/HTTPS debugging proxy to capture, inspect, modify, and replay traffic. `Freemium` `Open Source`
 - [SSH Keys Manager](https://github.com/Stmol/ssh-keys-manager-macos-app) - Native macOS app for managing SSH keys and SSH config entries. `Free` `Open Source`
 - [SF Symbols](https://developer.apple.com/sf-symbols/) - Browse and export Apple's SF Symbols. `Free`
 


### PR DESCRIPTION
## Description

Adds Rockxy to the Developer Tools section.

## App Details

**App Name:** Rockxy
**Category:** Developer Tools
**Website:** https://rockxy.io
**Pricing:** `Freemium` `Open Source`

Rockxy is a native macOS HTTP/HTTPS debugging proxy to capture, inspect, modify, and replay traffic. Built with Swift, SwiftUI/AppKit, and SwiftNIO — no Electron, no web views. Open source under AGPL-3.0 (source: https://github.com/RockxyApp/Rockxy).

## Checklist

- [x] Follows the formatting guidelines
- [x] Added in alphabetical order (between RocketSim and SSH Keys Manager)
- [x] Truly native (Swift/SwiftUI/AppKit/SwiftNIO, not Electron)
- [x] Link works
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] App is actively maintained (v0.23.0, released 2026-05-29)
- [x] No duplicate entry