### PR TITLE
Add Dusty to System Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [DaisyDisk](https://daisydiskapp.com/) - Analyze disk usage and free up space. `Paid`
 - [MonitorControl](https://github.com/MonitorControl/MonitorControl) - Control external monitor brightness & volume like native displays. `Free` `Open Source`
 - [DisplayBuddy](https://displaybuddy.app/) - Control the real brightness of monitors directly from Mac. `Paid`
+- [Dusty](https://github.com/yagcioglutoprak/dusty) - Menu bar disk cleaner that only deletes from a fixed allowlist and shows every path before removing it. `Free` `Open Source`
 - [Endurance](https://enduranceapp.com/) - Extend your MacBook's battery life. `Paid`
 - [EtreCheck](https://etrecheck.com/) - System configuration and diagnostic reporting. `Free`
 - [Hand Mirror](https://handmirror.app/) - One-click camera check from menu bar. `Free`


### PR DESCRIPTION
Adds Dusty to the System Utilities section.

Dusty is a native SwiftUI menu bar app that reclaims disk space from caches, logs, and developer junk. It only deletes from a fixed allowlist and shows every path and its size before removing anything. Free, MIT licensed, signed and notarized by Apple.

Meets the requirements:
- Native macOS (SwiftUI / AppKit), no Electron
- Actively maintained (v1.1.0)
- Available for download via Homebrew or a notarized DMG
- Open source: https://github.com/yagcioglutoprak/dusty

I am the developer. Placed alphabetically in System Utilities with the `Free` `Open Source` tags to match the existing format.