### PR TITLE
Add Helix (Terminal & Shell) and Flote (Note-Taking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Bear](https://bear.app/) - Beautiful, flexible writing app. `Freemium` `EU`
 - [Craft](https://www.craft.do/) - Native document editor with sharing. `Freemium`
 - [DEVONthink](https://www.devontechnologies.com/apps/devonthink) - Document and information management. `Paid`
+- [Flote](https://flote-app.vercel.app) - Floating sticky-note that turns messy scribbles into title, bullets and a checklist with one AI press; opens with Option+Space. `Free`
 - [Knopo](https://github.com/alkalim/Knopo) - Local-first Markdown outliner with backlinks and queries. `Free` `Open Source`
 - [FSNotes](https://fsnot.es/) - Modern notes manager for macOS. `Free` `Open Source`
 - [iA Writer](https://ia.net/writer) - Focused writing app with beautiful typography. `Paid`
@@ -371,6 +372,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 ## Terminal & Shell
 
 - [Alacritty](https://alacritty.org/) - GPU-accelerated terminal emulator. `Free` `Open Source`
+- [Helix](https://github.com/tomarai85/helix-releases) - Terminal workspace for running multiple Claude Code sessions in resizable panes, with browser preview and SSH in one window. `Free`
 - [iTerm2](https://iterm2.com/) - Terminal emulator for macOS. `Free` `Open Source`
 - [Kitty](https://sw.kovidgoyal.net/kitty/) - Fast, feature-rich GPU-based terminal. `Free` `Open Source`
 - [Terminal](https://support.apple.com/guide/terminal/) - Built-in macOS terminal. `Free`


### PR DESCRIPTION
Adding two native macOS apps, both written in Swift/SwiftUI (native, not Electron).

- **Helix** — a terminal workspace for running multiple Claude Code sessions in resizable panes, with a browser preview pane and SSH in one window. Free beta. Added under **Terminal & Shell** (alphabetical, after Alacritty). Tagged `Free` (closed-source).
- **Flote** — a floating sticky-note that turns messy scribbles into a title, bullets, and a checklist with one AI press; opens with Option+Space. Added under **Note-Taking & Writing** (alphabetical, after DEVONthink). Tagged `Free` (source-available under FSL; not labeled Open Source since FSL is not OSI-approved).

Both follow the existing one-line entry format. Links are public and working.