### PR TITLE
Add MacPass to Password Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,8 +291,8 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 ## Password Managers
 
-- [Strongbox](https://strongboxsafe.com/) - Native KeePass client for macOS. `Freemium`
 - [MacPass](https://macpassapp.org) - A native macOS KeePass client. `Free` `Open Source`
+- [Strongbox](https://strongboxsafe.com/) - Native KeePass client for macOS. `Freemium`
 
 ## PDF Tools
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 ## Password Managers
 
 - [Strongbox](https://strongboxsafe.com/) - Native KeePass client for macOS. `Freemium`
+- [MacPass](https://macpassapp.org) - A native macOS KeePass client. `Free` `Open Source`
 
 ## PDF Tools
 


### PR DESCRIPTION
## Description

<!-- Describe your changes -->

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:**  MacPass 
**Category:**  Password Managers
**Website:**  https://macpassapp.org
**Pricing:**  free

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

<!-- Any other information that might be helpful -->