### PR TITLE
Add Lockpaw (resubmission of #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Cryptomator](https://cryptomator.org/) - Multi-platform client-side encryption. `Free` `Open Source` `EU`
 - [KnockKnock](https://objective-see.org/products/knockknock.html) - See what's persistently installed on your Mac. `Free` `Open Source`
 - [Little Snitch](https://www.obdev.at/products/littlesnitch/) - Network monitor and firewall. `Paid` `EU`
+- [Lockpaw](https://github.com/sorkila/lockpaw) - Lock the screen while background tasks, builds, and AI agents keep running. `Free` `Open Source`
 - [Lulu](https://objective-see.org/products/lulu.html) - Open-source firewall for macOS. `Free` `Open Source`
 - [Micro Snitch](https://www.obdev.at/products/microsnitch/) - Monitor camera and microphone access. `Paid` `EU`
 - [OverSight](https://objective-see.org/products/oversight.html) - Monitor mic and webcam access. `Free` `Open Source`


### PR DESCRIPTION
## Description

This resubmits #48, which was auto-closed when I accidentally deleted the source fork during a cleanup — it was not rejected. Lockpaw is a native Swift macOS menu bar screen guard: cover and lock your screen with a hotkey without putting the Mac to sleep, so builds and AI agents keep running with input blocked; the locked screen glows when your agent needs you, and Touch ID unlocks. Free, MIT-licensed, no telemetry. Website: https://getlockpaw.com · Source: https://github.com/sorkila/lockpaw

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** Lockpaw
**Category:** Security & Privacy
**Website:** https://getlockpaw.com (source: https://github.com/sorkila/lockpaw)
**Pricing:** `Free` `Open Source`

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

Same entry and placement as the previously reviewed #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)