### PR TITLE
Add Headroom — Claude Code usage monitor for the menu bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [DatWeatherDoe](https://github.com/inderdhir/DatWeatherDoe) - Simple menu bar weather app. `Free` `Open Source`
 - [Dozer](https://github.com/Mortennn/Dozer) - Hide menu bar icons to give your Mac a cleaner look. `Free` `Open Source`
 - [Hand Mirror](https://handmirror.app/) - One-click camera check from menu bar. `Free`
+- [Headroom](https://github.com/patwalls/headroom) - Live Claude Code session (5h) and weekly (7d) usage in your menu bar — zero network calls, reads what Claude Code already writes locally. `Free` `Open Source`
 - [Hidden Bar](https://github.com/dwarvesf/hidden) - Hide menu bar items. `Free` `Open Source`
 - [HomeBar for Homey Pro](https://homebar.pro) - Manage your Homey Pro smart home. `Freemium`
 - [Itsycal](https://www.mowglii.com/itsycal/) - Tiny menu bar calendar. `Free` `Open Source`


### PR DESCRIPTION
## What
Adds [Headroom](https://github.com/patwalls/headroom) to the Menu Bar Apps section, alphabetically between Hand Mirror and Hidden Bar.

## Why it belongs here
Headroom is a native Swift/AppKit macOS menu bar app — no Electron, no webview, ~267 KB. It shows Claude Code's 5-hour session and 7-day weekly usage as a live percentage, color-coded as limits approach. Free, MIT, signed & notarized.

**Architecture highlight:** Unlike most Claude usage monitors that poll an API, Headroom makes zero network calls. It installs a tiny status-line hook that runs inside Claude Code; Claude Code writes its own rate-limit JSON to a local file; Headroom reads that file. Run `nettop -p headroom` — you'll see nothing.

- Install: `brew install --cask patwalls/tap/headroom` or download from https://headroom.walls.sh
- Source: https://github.com/patwalls/headroom (~700 lines of Swift, MIT)