### PR TITLE
Add Vibedock — macOS menu bar app for managing Claude Code MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Rockxy](https://rockxy.io) - macOS HTTP/HTTPS debugging proxy to capture, inspect, modify, and replay traffic. `Freemium` `Open Source`
 - [SSH Keys Manager](https://github.com/Stmol/ssh-keys-manager-macos-app) - Native macOS app for managing SSH keys and SSH config entries. `Free` `Open Source`
 - [SF Symbols](https://developer.apple.com/sf-symbols/) - Browse and export Apple's SF Symbols. `Free`
+- [Vibedock](https://vibedock.dev/) - Manage Claude Code MCP servers from your macOS menu bar. `Paid (one-time)`
 
 ## Email & Communication
 


### PR DESCRIPTION
Vibedock is a native macOS menu bar app that manages Claude Code MCP servers from the menu bar.

Website: https://vibedock.dev
Category: Developer Tools
Pricing: Paid (one-time)
Native macOS: Yes
Menu bar: Yes