### PR TITLE
Add Painless Belt to Security & Privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Lulu](https://objective-see.org/products/lulu.html) - Open-source firewall for macOS. `Free` `Open Source`
 - [Micro Snitch](https://www.obdev.at/products/microsnitch/) - Monitor camera and microphone access. `Paid` `EU`
 - [OverSight](https://objective-see.org/products/oversight.html) - Monitor mic and webcam access. `Free` `Open Source`
+- [Painless Belt](https://github.com/shshemi/painless-belt) - Sandbox any command-line tool using macOS Seatbelt. `Free` `Open Source`
 
 ## System Utilities
 


### PR DESCRIPTION
Adds **Painless Belt** to the **Security & Privacy** category.

[Painless Belt](https://github.com/shshemi/painless-belt) (`pb`) is a lightweight CLI that wraps macOS's Seatbelt sandbox API to run any command-line tool inside a configurable sandbox, scoping its filesystem and network access. It ships with a profile system and ready-made profiles for common dev tools and AI CLIs.

- **Native:** macOS-specific — built directly on the macOS Seatbelt (`sandbox`) API.
- **Lightweight:** a small, fast Rust binary; no Electron, no web wrapper.
- **Open source & free:** MIT licensed.

### PR Checklist
- [x] App is truly native (not Electron/web wrapper)
- [x] App is in the correct category
- [x] Alphabetically ordered within category
- [x] Follows formatting guidelines exactly
- [x] Description is concise and objective
- [x] Link works and points to official repo
- [x] Pricing label is accurate (`Free` `Open Source`)
- [x] No duplicate entries
- [x] Commit message is clear