### PR TITLE
Add mysa

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Itsycal](https://www.mowglii.com/itsycal/) - Tiny menu bar calendar. `Free` `Open Source`
 - [Itsyhome](https://github.com/nickustinov/itsyhome-macos) - Smart home meets menu bar. `Freemium` `Open Source`
 - [MenubarX](https://menubarx.app/) - Browser in your menu bar. `Freemium`
+- [mysa](https://github.com/alishansnsn/mysa) - Quick breathing breaks with a frosted screen overlay and handwritten quotes. `Free` `Open Source`
 - [One Thing](https://sindresorhus.com/one-thing) - Put a single task in your menu bar. `Paid`
 - [OpenQuack](https://github.com/larryxiao/openquack) - Transcribes a 5-minute clip in 2.8 s — local WhisperKit dictation, noise-robust. ~8 MB native Swift. `Free` `Open Source`
 - [SaneBar](https://sanebar.com) - Privacy-first menu bar manager. Hide and organize icons. `Freemium`


### PR DESCRIPTION
## Description

Adds mysa to the Menu Bar Apps section. It is a native macOS menu bar app for quick breathing breaks. It shows a frosted screen overlay with handwritten quotes while you take a short break.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** mysa
**Category:** Menu Bar Apps
**Website:** https://github.com/alishansnsn/mysa
**Pricing:** Free, Open Source (MIT)

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

mysa is built with Swift and SwiftUI, runs on macOS 14 and later, lives in the menu bar, and is free and open source under the MIT license.
