### PR TITLE
Add Pesty to Clipboard Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Maccy](https://github.com/p0deje/Maccy) - Lightweight clipboard manager with search. `Free` `Open Source`
 - [CopyClip](https://fiplab.com/apps/copyclip-for-mac) - Lightweight clipboard history manager. `Free`
 - [Paste](https://pasteapp.io/) - Beautiful clipboard manager with cloud sync. `Subscription`
+- [Pesty](https://github.com/momenbasel/pesty) - Native clipboard manager with pinboards and keyboard-driven pasting. `Free` `Open Source`
 - [Unclutter](https://unclutterapp.com/) - Files, notes, and clipboard manager in one. `Paid`
 
 ## Color Pickers


### PR DESCRIPTION
## Adding Pesty to Clipboard Managers

Pesty is a free, open-source, fully native SwiftUI clipboard manager for macOS - a slide-up, color-coded clipboard strip with pinboards, instant search, and keyboard-driven pasting.

**Why it fits this list:**
- Native: 100% SwiftUI/AppKit, zero third-party dependencies - the exact native-over-Electron thesis this list curates.
- Lightweight: Universal binary, small footprint, fast slide-up panel.
- Trustworthy distribution: Developer ID signed and Apple-notarized; installable via Homebrew (`brew install --cask momenbasel/pesty/pesty`).
- Open source: MIT licensed - https://github.com/momenbasel/pesty
- Actively maintained (pushed 2026-06).
- Slots cleanly alongside existing peers in the Clipboard Managers section (Maccy, Paste).

**Entry added (Clipboard Managers, after Paste, before Unclutter):**

`- [Pesty](https://github.com/momenbasel/pesty) - Native clipboard manager with pinboards and keyboard-driven pasting. ` + "`Free` `Open Source`"

**Links:**
- Repo: https://github.com/momenbasel/pesty
- Landing page: https://www.moamenbasel.com/pesty/

### PR Checklist
- [x] App is truly native (SwiftUI/AppKit, no Electron/web wrapper, zero third-party deps)
- [x] Correct category (Clipboard Managers)
- [x] Alphabetically ordered within category
- [x] Follows formatting guidelines exactly
- [x] Description is concise (<100 chars) and objective
- [x] Link works and points to the official repo
- [x] Pricing label accurate (free + MIT via Homebrew; `Free` `Open Source`, same convention as Maccy)
- [x] No duplicate entries

Disclosure: I'm involved with Pesty. Sharing it because it matches the list's native/no-dependency criteria one-for-one; happy to defer to maintainer judgment per the self-submission guideline.