### PR TITLE
Add TranslateAir to Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Stargazer Bar](https://jazzyalex.github.io/stargazer-bar/) - Track one public GitHub repo's stars and release downloads from your menu bar. `Free` `Open Source`
 - [Thaw](https://github.com/stonerl/Thaw) - Powerful menu bar management tool. Fork of Ice, lower resource usage. `Free` `Open Source`
 - [TickerPad](https://tickerpad.app) - Real-time crypto prices in your macOS menu bar.  `Freemium`
+- [TranslateAir](https://www.translateair.com/) - AI translation and OCR from the menu bar, 100+ languages. `Freemium`
 
 ## Network Tools
 


### PR DESCRIPTION
## Summary

- Adds [TranslateAir](https://www.translateair.com/) to the **Menu Bar Apps** section
- Placed in alphabetical order after TickerPad

## App Details

- **Name**: TranslateAir
- **Category**: Menu Bar Apps
- **URL**: https://www.translateair.com/
- **Pricing**: Freemium (free tier with 50 translations, paid subscription for unlimited)
- **Description**: AI translation and OCR from the menu bar, 100+ languages.

## App checklist

- [x] Native macOS app (distributed as .dmg)
- [x] Menu bar app with pop-up floating translation bar
- [x] Supports AI engines: ChatGPT, Gemini, DeepL, Google Translate
- [x] OCR text extraction from screenshots, designs, videos, PDFs
- [x] 100+ language support
- [x] Actively maintained (© 2026)
- [x] Alphabetically ordered within category
- [x] Follows formatting guidelines

## PR Checklist

- [x] App is truly native (not Electron/web wrapper)
- [x] App is in the correct category
- [x] Alphabetically ordered within category
- [x] Follows formatting guidelines exactly
- [x] Description is concise and objective
- [x] Link works and points to official site
- [x] Pricing label is accurate
- [x] No duplicate entries
- [x] Commit message is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)