### PR TITLE
Add Blurt to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 - [Alfred](https://www.alfredapp.com/) - Productivity app for macOS with powerful workflows. `Freemium`
 - [BetterTouchTool](https://folivora.ai/) - Customize input devices on your Mac. `Paid` `EU`
+- [Blurt](https://blurtblurt.com) - Hold-a-hotkey dictation that pastes cleaned-up text into any app, using AssemblyAI cloud speech-to-text. `Free` `Open Source`
 - [Due](https://www.dueapp.com/) - Reminders with persistent alerts. `Paid`
 - [Fantastical](https://flexibits.com/fantastical) - Calendar app with natural language input. `Subscription`
 - [Focus](https://heyfocus.com/) - Block distracting websites and applications. `Paid`


### PR DESCRIPTION
Adds [Blurt](https://blurtblurt.com) to **Productivity** (alphabetically, after BetterTouchTool).

Blurt is a native Swift/SwiftUI macOS dictation app (no Electron, MIT-licensed, actively maintained): hold a hotkey, speak, and cleaned-up text is pasted into the focused app. It uses AssemblyAI's cloud speech-to-text (bring your own key, free tier).

Fits the list's criteria (native macOS frameworks, maintained). Follows the formatting guide: one line, trailing period, `Free` `Open Source` pricing labels, alphabetical placement.

- Repo: https://github.com/alexkroman/blurt