### PR TITLE
Add Settle

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Nudge](https://nudge.run) - Free window manager with keyboard shortcuts and drag-to-edge snapping. `Free` `Open Source`
 - [Rectangle](https://rectangleapp.com/) - Window snapping via keyboard shortcuts. `Free` `Open Source`
 - [Rectangle Pro](https://rectangleapp.com/pro) - Professional window management. `Paid`
+- [Settle](https://settle.gokhangokova.com/) - Saves window layouts and switches them automatically on monitor, time, or app launch. `Paid`
 - [Swish](https://highlyopinionated.co/swish/) - Control windows with trackpad gestures. `Paid`
 - [Wins](https://wins.cool) - Bring system-level window management features to macOS. `Paid`
 - [Yabai](https://github.com/koekeishiya/yabai) - Tiling window manager for macOS. `Free` `Open Source`


### PR DESCRIPTION
## Description

Adds Settle to the Window Management section. A native macOS window manager that saves window layouts and switches them automatically on monitor connect/disconnect, time of day, or app launch.

## Type of Change

- [x] Add new app

## App Details (if adding new app)

**App Name:** Settle
**Category:** Window Management
**Website:** https://settle.gokhangokova.com/
**Pricing:** Paid ($9.99 one-time, 7-day trial)

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

Developer ID signed and notarized DMG, not on the Mac App Store.