### PR TITLE
Add tty7 to Terminal & Shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [iTerm2](https://iterm2.com/) - Terminal emulator for macOS. `Free` `Open Source`
 - [Kitty](https://sw.kovidgoyal.net/kitty/) - Fast, feature-rich GPU-based terminal. `Free` `Open Source`
 - [Terminal](https://support.apple.com/guide/terminal/) - Built-in macOS terminal. `Free`
+- [tty7](https://github.com/l0ng-ai/tty7) - GPU-rendered, daemon-backed terminal in pure Rust; sessions persist without tmux. `Free` `Open Source`
 - [Warp](https://www.warp.dev/) - Rust-based terminal with modern features. `Free`
 
 ## Text Editors


### PR DESCRIPTION
Adds **tty7** — a GPU-rendered, daemon-backed terminal emulator written in pure Rust (built on Zed's gpui and Alacritty's VT core).

A persistent daemon holds the PTYs, so terminal sessions survive quitting the app — no tmux needed. It ships an enhanced prompt (completion, syntax highlighting, history, in-terminal search), tabs, splits, a command palette, 8 themes, and CJK/IME input, with native builds for macOS (signed & notarized), Windows, and Linux.

- Repo: https://github.com/l0ng-ai/tty7
- License: Apache-2.0

Added in alphabetical order, following the list's existing format.
