### PR TITLE
Add Peeku Presence Coach to Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [MenubarX](https://menubarx.app/) - Browser in your menu bar. `Freemium`
 - [One Thing](https://sindresorhus.com/one-thing) - Put a single task in your menu bar. `Paid`
 - [OpenQuack](https://github.com/larryxiao/openquack) - Transcribes a 5-minute clip in 2.8 s — local WhisperKit dictation, noise-robust. ~8 MB native Swift. `Free` `Open Source`
+- [Peeku Presence Coach](https://apps.apple.com/app/peeku-presence-coach/id6773651327?mt=12) - Menu bar coach for eye breaks, walk reminders, and local presence signals. `Free`
 - [SaneBar](https://sanebar.com) - Privacy-first menu bar manager. Hide and organize icons. `Freemium`
 - [Stargazer Bar](https://jazzyalex.github.io/stargazer-bar/) - Track one public GitHub repo's stars and release downloads from your menu bar. `Free` `Open Source`
 - [Thaw](https://github.com/stonerl/Thaw) - Powerful menu bar management tool. Fork of Ice, lower resource usage. `Free` `Open Source`


### PR DESCRIPTION
## Description

Add Peeku Presence Coach to the Menu Bar Apps category.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** Peeku Presence Coach
**Category:** Menu Bar Apps
**Website:** https://apps.apple.com/app/peeku-presence-coach/id6773651327?mt=12
**Pricing:** Free

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

Peeku Presence Coach is a native macOS menu bar app focused on local presence signals, eye breaks, and walk reminders.
