### PR TITLE
Add Noticky to Note-Taking & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [iA Writer](https://ia.net/writer) - Focused writing app with beautiful typography. `Paid`
 - [Notational Velocity](http://notational.net/) - Modeless note-taking application. `Free` `Open Source`
 - [Notebooks](https://www.notebooksapp.com/) - Write, organize, and manage information. `Paid`
+- [Noticky](https://www.noticky.app/en) - Sticky notes that stay above every window, including fullscreen apps. `Paid` `EU`
 - [nvALT](https://brettterpstra.com/projects/nvalt/) - Fork of Notational Velocity with additional features. `Free` `Open Source`
 - [The Archive](https://zettelkasten.de/the-archive/) - Note-taking app for writers and researchers. `Paid`
 - [Tot](https://tot.rocks/) - Elegant text collection on menu bar. `Freemium`


### PR DESCRIPTION
## Description

Add Noticky to Note-Taking & Writing. Noticky is a native SwiftUI/AppKit sticky notes app that keeps notes above fullscreen apps.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** Noticky  
**Category:** Note-Taking & Writing  
**Website:** https://www.noticky.app/en  
**Pricing:** Paid (one-time purchase)  

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

Developer submission for transparency. Noticky is built with SwiftUI and AppKit, requires macOS 15 or later, and is actively maintained. Its native window integration keeps notes visible above fullscreen apps. Complimentary licenses are available to maintainers for evaluation.
