### PR TITLE
Add usage to Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Thaw](https://github.com/stonerl/Thaw) - Powerful menu bar management tool. Fork of Ice, lower resource usage. `Free` `Open Source`
 - [TickerPad](https://tickerpad.app) - Real-time crypto prices in your macOS menu bar.  `Freemium`
 - [TranslateAir](https://www.translateair.com/) - AI translation and OCR from the menu bar, 100+ languages. `Freemium`
+- [usage](https://github.com/aqua5230/usage) - Claude Code and Codex quota pinned to the menu bar, with burn-rate predictions and offline HTML reports. Never calls the API — reads local files only. `Free` `Open Source`
 
 ## Network Tools
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Thaw](https://github.com/stonerl/Thaw) - Powerful menu bar management tool. Fork of Ice, lower resource usage. `Free` `Open Source`
 - [TickerPad](https://tickerpad.app) - Real-time crypto prices in your macOS menu bar.  `Freemium`
 - [TranslateAir](https://www.translateair.com/) - AI translation and OCR from the menu bar, 100+ languages. `Freemium`
-- [usage](https://github.com/aqua5230/usage) - Claude Code and Codex quota pinned to the menu bar, with burn-rate predictions and offline HTML reports. Never calls the API — reads local files only. `Free` `Open Source`
+- [usage](https://github.com/aqua5230/usage) - Claude Code, Codex, and Antigravity quota pinned to the menu bar, with burn-rate predictions and offline HTML reports. No LLM API calls — Claude Code and Codex read local files only. `Free` `Open Source`
 
 ## Network Tools
 


### PR DESCRIPTION
Adds [usage](https://github.com/aqua5230/usage) to **Menu Bar Apps** (alphabetical order).

- Native menu bar app built with PyObjC calling AppKit directly — no Electron, no web wrapper
- Pins Claude Code and Codex quota (5-hour / weekly) to the menu bar with burn-rate predictions and offline HTML reports
- Never calls the Anthropic/OpenAI API and never reads the Keychain; all numbers come from local files, zero token overhead
- Free, open source (AGPL-3.0), installable via `brew install --cask aqua5230/usage/usage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)