### PR TITLE
Add Nimclip to Clipboard Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,9 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 ## Clipboard Managers
 
-- [Maccy](https://github.com/p0deje/Maccy) - Lightweight clipboard manager with search. `Free` `Open Source`
 - [CopyClip](https://fiplab.com/apps/copyclip-for-mac) - Lightweight clipboard history manager. `Free`
+- [Maccy](https://github.com/p0deje/Maccy) - Lightweight clipboard manager with search. `Free` `Open Source`
+- [Nimclip](https://hukdoesn.github.io/Nimclip/) - Local-first clipboard history with search, tags, and quick paste. `Free` `Open Source`
 - [Paste](https://pasteapp.io/) - Beautiful clipboard manager with cloud sync. `Subscription`
 - [Pesty](https://github.com/momenbasel/pesty) - Native clipboard manager with pinboards and keyboard-driven pasting. `Free` `Open Source`
 - [Unclutter](https://unclutterapp.com/) - Files, notes, and clipboard manager in one. `Paid`


### PR DESCRIPTION
## Description

Adds Nimclip, a free and open-source native clipboard history manager, to the Clipboard Managers category.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** Nimclip
**Category:** Clipboard Managers
**Website:** https://hukdoesn.github.io/Nimclip/
**Pricing:** Free, Open Source

## Checklist

- [x] My app follows the formatting guidelines
- [x] I have added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I have read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

Nimclip is built with Swift, SwiftUI, and SwiftData. Clipboard data stays on the local Mac.

## Screenshots

![Nimclip main interface](https://raw.githubusercontent.com/hukdoesn/Nimclip/main/docs/images/nimclip-main-real.png)

![Nimclip themes](https://raw.githubusercontent.com/hukdoesn/Nimclip/main/docs/images/nimclip-macbook-themes.png)

![Nimclip image preview](https://raw.githubusercontent.com/hukdoesn/Nimclip/main/docs/images/nimclip-image-preview-real.png)