### PR TITLE
Add Terminal Candy to Terminal & Shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [iTerm2](https://iterm2.com/) - Terminal emulator for macOS. `Free` `Open Source`
 - [Kitty](https://sw.kovidgoyal.net/kitty/) - Fast, feature-rich GPU-based terminal. `Free` `Open Source`
 - [Terminal](https://support.apple.com/guide/terminal/) - Built-in macOS terminal. `Free`
+- [Terminal Candy](https://terminalcandy.com/) - Skinnable terminal that turns any image into a working terminal, with AI-agent alerts. `Paid`
 - [Warp](https://www.warp.dev/) - Rust-based terminal with modern features. `Free`
 
 ## Text Editors


### PR DESCRIPTION
Adds **[Terminal Candy](https://terminalcandy.com)** to Terminal & Shell (alphabetical, between Terminal and Warp).

Fully native Swift/AppKit + SwiftTerm — no Electron, no web wrapper. Every skin composites a live terminal (real PTY: full VT, true color, multi-session) behind any image; the built-in Skin Builder turns any picture into a working terminal, and agent alerts ping you when AI CLIs (Claude Code, Codex, Gemini) finish. `Paid` tag per convention — $10 one-time with a free 14-day trial.

Disclosure: I'm the developer.