### PR TITLE
Add Ask Iris to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 ## Productivity
 
 - [Alfred](https://www.alfredapp.com/) - Productivity app for macOS with powerful workflows. `Freemium`
+- [Ask Iris](https://askiris.store/) - Private on-device AI workspaces for chatting with images, documents, and video clips. `Freemium`
 - [BetterTouchTool](https://folivora.ai/) - Customize input devices on your Mac. `Paid` `EU`
 - [Blurt](https://blurtblurt.com) - Hold-a-hotkey dictation that pastes cleaned-up text into any app, using AssemblyAI cloud speech-to-text. `Free` `Open Source`
 - [Due](https://www.dueapp.com/) - Reminders with persistent alerts. `Paid`


### PR DESCRIPTION
## Description

Adds Ask Iris to the Productivity category. Ask Iris is a native, on-device AI workspace for chatting with images, documents, and video clips.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** Ask Iris  
**Category:** Productivity  
**Website:** https://askiris.store/  
**Pricing:** Freemium  

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

Ask Iris is built with Swift and SwiftUI and is distributed through the Mac App Store. It includes a free trial with an optional one-time Pro unlock.
