### PR TITLE
Add Dimmerly to Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Bartender](https://www.macbartender.com/) - Organize your menu bar icons. `Paid`
 - [Commitments](https://commitments.pages.dev/) - Your tasks in menu bar. `Paid`
 - [DatWeatherDoe](https://github.com/inderdhir/DatWeatherDoe) - Simple menu bar weather app. `Free` `Open Source`
+- [Dimmerly](https://github.com/olujicz/Dimmerly) - Control display brightness, warmth, and contrast from the menu bar. `Free` `Open Source`
 - [Dozer](https://github.com/Mortennn/Dozer) - Hide menu bar icons to give your Mac a cleaner look. `Free` `Open Source`
 - [Hand Mirror](https://handmirror.app/) - One-click camera check from menu bar. `Free`
 - [Headroom](https://github.com/patwalls/headroom) - Live Claude Code session (5h) and weekly (7d) usage in your menu bar — zero network calls, reads what Claude Code already writes locally. `Free` `Open Source`


### PR DESCRIPTION
## Description

Add Dimmerly, a native macOS menu bar app for controlling display brightness, warmth, and contrast.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** Dimmerly  
**Category:** Menu Bar Apps  
**Website:** https://github.com/olujicz/Dimmerly  
**Pricing:** Free, Open Source  

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

This is a developer submission. Dimmerly is an MIT-licensed Swift/SwiftUI app with a stable v1.1.2 release. It supports native display controls, DDC/CI external-monitor controls, presets, schedules, keyboard shortcuts, and a widget.
