### PR TITLE
Add echo99 to Screenshot & Recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 - [BetterCapture](https://bettercapture.app/) - A lightweight, and intuitive screen recorder with a native look and feel. `Free` `Open Source`
 - [CleanShot X](https://cleanshot.com/) - Capture your Mac's screen like a pro. `Paid`
+- [echo99](https://www.echo99.app/) - Records calls with on-device transcription and separate mic and system tracks. `Free`
 - [Gifox](https://gifox.app/) - Delightful GIF recording and sharing. `Paid`
 - [Kap](https://getkap.co/) - Open-source screen recorder. `Free` `Open Source`
 - [ScreenFloat](https://eternalstorms.at/screenfloat/) - Screenshot utility with floating thumbnails. `Paid` `EU`


### PR DESCRIPTION
## Description

Adds echo99 to Screenshot & Recording. echo99 is a native SwiftUI/AppKit menu-bar app that records microphone and system audio as separate tracks and transcribes calls on-device.

Disclosure: I am the developer. The current notarized DMG is 8.6 MB, the app is free, and its recording and transcription workflow runs locally without a meeting bot or account.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** echo99  
**Category:** Screenshot & Recording  
**Website:** https://www.echo99.app/  
**Pricing:** Free  

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

- Built with SwiftUI and AppKit.
- Requires macOS 14.4 or later.
- The website and download endpoint were verified before submission.
