### PR TITLE
Add Notchpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Itsycal](https://www.mowglii.com/itsycal/) - Tiny menu bar calendar. `Free` `Open Source`
 - [Itsyhome](https://github.com/nickustinov/itsyhome-macos) - Smart home meets menu bar. `Freemium` `Open Source`
 - [MenubarX](https://menubarx.app/) - Browser in your menu bar. `Freemium`
+- [Notchpad](https://github.com/BirdyTheDev/notchpad) - Modular panel in the MacBook notch: Claude Code sessions and token usage, file shelf, keep-awake, system stats, Unity and MCP status. `Free` `Open Source`
 - [One Thing](https://sindresorhus.com/one-thing) - Put a single task in your menu bar. `Paid`
 - [OpenQuack](https://github.com/larryxiao/openquack) - Transcribes a 5-minute clip in 2.8 s — local WhisperKit dictation, noise-robust. ~8 MB native Swift. `Free` `Open Source`
 - [SaneBar](https://sanebar.com) - Privacy-first menu bar manager. Hide and organize icons. `Freemium`


### PR DESCRIPTION
Adds [Notchpad](https://github.com/BirdyTheDev/notchpad) to **Menu Bar Apps**, in alphabetical order.

Meets the requirements:

- Native: Swift with AppKit and SwiftUI, no dependencies, no Electron
- Lightweight: a borderless panel plus a menu bar item; sensors poll every 2s off the main thread
- Actively maintained: first public release this week
- Available: builds from source with `./build.sh && ./install.sh`, macOS 14+ on Apple Silicon
- Free and MIT licensed

It turns the notch into a panel you assemble yourself — a file shelf you drag files in and out of, system and memory readouts, battery, pomodoro, keep-awake, your own shell commands, and modules for Claude Code sessions, Unity projects and MCP server health. Each module can be switched off and reordered.