### PR TITLE
Add RelayBar to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [DevUtils](https://devutils.com/) - All-in-one offline toolbox for developers (42+ tools). `Freemium`
 - [Paw](https://paw.cloud/) - Advanced API tool for Mac. `Paid`
 - [Proxyman](https://proxyman.io/) - Native HTTP debugging proxy. `Freemium`
+- [RelayBar](https://github.com/lx2026/RelayBar) - Manage SSH tunnels and preview remote files from the menu bar. `Free` `Open Source`
 - [RocketSim](https://www.rocketsim.app/) - Enhance Xcode Simulator productivity. `Freemium`
 - [Rockxy](https://rockxy.io) - macOS HTTP/HTTPS debugging proxy to capture, inspect, modify, and replay traffic. `Freemium` `Open Source`
 - [SSH Keys Manager](https://github.com/Stmol/ssh-keys-manager-macos-app) - Native macOS app for managing SSH keys and SSH config entries. `Free` `Open Source`


### PR DESCRIPTION
## Description

Adds RelayBar to Developer Tools. RelayBar is a free, open-source native
Swift/SwiftUI macOS menu-bar app for managing SSH tunnels and previewing or
downloading remote files over SFTP.

Maintainer disclosure: I maintain RelayBar.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** RelayBar  
**Category:** Developer Tools  
**Website:** https://github.com/lx2026/RelayBar  
**Pricing:** Free, open source  

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

RelayBar has a stable, universal, Developer ID-signed and notarized release. Its
combined SSH-forwarding and exact-path remote-file preview workflow is not
currently represented in the Developer Tools category.
