### PR TITLE
Add Yap to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Things](https://culturedcode.com/things/) - Award-winning task manager. `Paid`
 - [Tot](https://tot.rocks/) - Elegant text collection on menu bar. `Freemium`
 - [Speakmac](https://www.speakmac.app/) - Offline hotkey dictation for macOS that types into any app using on-device transcription. `One-Time Subscription`
+- [Yap](https://github.com/FrigadeHQ/yap) - On-device voice dictation from the menu bar with a hotkey to talk and no model to download. `Free` `Open Source`
 
 ## Screenshot & Recording
 


### PR DESCRIPTION
Adds Yap, an open source menu bar app for on-device voice dictation on macOS.

You set a hotkey, talk, and the text is pasted into whatever field you were typing in. It is native Swift, around 4 MB, and uses the built-in macOS 26 speech APIs, so there is no model to download and no network code at all. Fits the native and lightweight theme of the list, alongside Blurt and Speakmac. MIT licensed.

https://github.com/FrigadeHQ/yap