### PR TITLE
Add ClaudeNotch to Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 ## Menu Bar Apps
 
 - [Bartender](https://www.macbartender.com/) - Organize your menu bar icons. `Paid`
+- [ClaudeNotch](https://github.com/hidrogenone/ClaudeNotch) - Notch drops down with an alert when Claude has an outage. Pure SwiftUI/AppKit, ~500 KB. `Free` `Open Source`
 - [Commitments](https://commitments.pages.dev/) - Your tasks in menu bar. `Paid`
 - [DatWeatherDoe](https://github.com/inderdhir/DatWeatherDoe) - Simple menu bar weather app. `Free` `Open Source`
 - [Dozer](https://github.com/Mortennn/Dozer) - Hide menu bar icons to give your Mac a cleaner look. `Free` `Open Source`


### PR DESCRIPTION
Adds **[ClaudeNotch](https://github.com/hidrogenone/ClaudeNotch)** to the Menu Bar Apps section.

A menu bar app that watches Claude's public status page. On an incident it slides a Dynamic-Island-style alert down out of the MacBook notch showing the affected services, and pulses the screen edges red; hovering the notch shows live per-component health any time.

Fits the list's native-first criteria:
- Pure Swift/SwiftUI + AppKit — no Electron, no web view, no bundled runtime
- ~500 KB binary, zero third-party dependencies
- One HTTPS request to a JSON status endpoint; no analytics, no accounts
- MIT licensed and free

Placed alphabetically between Bartender and Commitments.