### PR TITLE
Add ItsPaint to Image & Graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 - [Acorn](https://flyingmeat.com/acorn/) - Full-featured photo editor designed for humans. `Paid`
 - [ImageOptim](https://imageoptim.com/) - Compress images without losing quality. `Free` `Open Source`
+- [ItsPaint](https://sites.fynesite.com/itspaint/) - Focused paint and screenshot markup: step badges, pixelate redaction, Instant Alpha. `Free` `Open Source`
 - [Pixave](https://www.pixaveapp.com/) - Ultimate image organizer and viewer. `Paid`
 - [Pixelmator Pro](https://www.pixelmator.com/pro/) - Powerful native image editor. `Paid` `EU`
 - [Retrobatch](https://flyingmeat.com/retrobatch/) - Batch image processing for Mac. `Paid`


### PR DESCRIPTION
ItsPaint is a free, MIT-licensed paint and screenshot-markup app built with AppKit and SwiftUI: zero third-party dependencies, no Electron, no web views, universal binary, macOS 14+. Signed and notarised releases.

It exists for the markup jobs the built-in tools skip: numbered step badges, pixelate redaction, Instant Alpha, real transparency. No account, no telemetry, and no network code at all, which the sandbox entitlements make checkable.

- Source: https://github.com/joshlin2201/itspaint
- Install: `brew install --cask joshlin2201/itspaint/itspaint`

Alphabetical in Image & Graphics, format matched. I am the developer.