### PR TITLE
Add Waindow to Window Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Rectangle](https://rectangleapp.com/) - Window snapping via keyboard shortcuts. `Free` `Open Source`
 - [Rectangle Pro](https://rectangleapp.com/pro) - Professional window management. `Paid`
 - [Swish](https://highlyopinionated.co/swish/) - Control windows with trackpad gestures. `Paid`
+- [Waindow](https://www.waindow.app/) - Arrange windows with linked resizing, notes, capture, and Keep Awake. `Free`
 - [Wins](https://wins.cool) - Bring system-level window management features to macOS. `Paid`
 - [Yabai](https://github.com/koekeishiya/yabai) - Tiling window manager for macOS. `Free` `Open Source`
 


### PR DESCRIPTION
## Description

Adds Waindow to Window Management in alphabetical order with an objective description and its current free pricing.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** Waindow  
**Category:** Window Management  
**Website:** https://www.waindow.app/  
**Pricing:** Free  

## Checklist

- [x] My app follows the formatting guidelines
- [x] I have added the app in alphabetical order
- [x] The app is truly native (SwiftUI and AppKit, not Electron or a web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I have read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

The current public build is Waindow 1.4.1 for macOS 13.1 or later. The app is free and account-free.