### PR TITLE
Add MistBar (Menu Bar Apps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Itsycal](https://www.mowglii.com/itsycal/) - Tiny menu bar calendar. `Free` `Open Source`
 - [Itsyhome](https://github.com/nickustinov/itsyhome-macos) - Smart home meets menu bar. `Freemium` `Open Source`
 - [MenubarX](https://menubarx.app/) - Browser in your menu bar. `Freemium`
+- [MistBar](https://mistbar.app) - Declutter and hide menu bar icons, plus built-in mail, notes, clipboard, and AI-usage tools. `Paid`
 - [One Thing](https://sindresorhus.com/one-thing) - Put a single task in your menu bar. `Paid`
 - [OpenQuack](https://github.com/larryxiao/openquack) - Transcribes a 5-minute clip in 2.8 s — local WhisperKit dictation, noise-robust. ~8 MB native Swift. `Free` `Open Source`
 - [SaneBar](https://sanebar.com) - Privacy-first menu bar manager. Hide and organize icons. `Freemium`


### PR DESCRIPTION
Adds **MistBar** to the **Menu Bar Apps** category (alphabetical, between MenubarX and One Thing).

Meets the App Requirements:

- ✅ Native — pure Swift + AppKit, no Electron or web wrappers
- ✅ Lightweight and performant; follows the macOS HIG
- ✅ Actively maintained; available for download at https://mistbar.app
- ✅ No malware/spyware

MistBar declutters and hides menu bar icons, with built-in mail, notes, clipboard, and AI-usage tools. `Paid` (one-time purchase).