### PR TITLE
Add Shieldxy to Security & Privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Lulu](https://objective-see.org/products/lulu.html) - Open-source firewall for macOS. `Free` `Open Source`
 - [Micro Snitch](https://www.obdev.at/products/microsnitch/) - Monitor camera and microphone access. `Paid` `EU`
 - [OverSight](https://objective-see.org/products/oversight.html) - Monitor mic and webcam access. `Free` `Open Source`
+- [Shieldxy](https://rockxy.io/shieldxy) - Native macOS application firewall for monitoring and controlling outbound connections by app. `Free` `Open Source`
 
 ## System Utilities
 


### PR DESCRIPTION
## What changed

- Add Shieldxy to the Security & Privacy section.
- Describe it as a native macOS application firewall for outbound connections.
- Mark it as free and open source.

## Why

Shieldxy is an open-source native macOS application firewall that monitors and controls outbound connections by app.

## Notes

Shieldxy is currently a source preview; the first signed and notarized public binary has not been published yet.

## Validation

- Verified the official website and repository links return HTTP 200.
- Kept the entry alphabetically ordered.
- Ran `git diff --check`.
