### PR TITLE
Add Tracexy to Network Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Micro Snitch](https://www.obdev.at/products/microsnitch/) - Monitor camera and microphone access. `Paid` `EU`
 - [NetNewsWire](https://netnewswire.com/) - RSS reader for macOS. `Free` `Open Source`
 - [Surge](https://nssurge.com/) - Advanced network toolbox for Mac. `Paid`
+- [Tracexy](https://rockxy.io/tracexy) - Native macOS packet analyzer for live and saved PCAP/PCAPNG captures. `Free` `Open Source`
 - [WiFi Explorer](https://www.intuitibits.com/products/wifi-explorer/) - Scan, monitor and troubleshoot wireless networks. `Paid`
 
 ## Note-Taking & Writing


### PR DESCRIPTION
## Description

Add Tracexy to the Network Tools section as an actively maintained native macOS packet analyzer.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** Tracexy  
**Category:** Network Tools  
**Website:** https://rockxy.io/tracexy  
**Pricing:** Free, Open Source  

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

Tracexy is built with SwiftUI and AppKit. It provides local-first packet analysis for live and saved PCAP/PCAPNG captures through a native macOS interface.
