### PR TITLE
Add SeqLog to Note-Taking & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Notational Velocity](http://notational.net/) - Modeless note-taking application. `Free` `Open Source`
 - [Notebooks](https://www.notebooksapp.com/) - Write, organize, and manage information. `Paid`
 - [nvALT](https://brettterpstra.com/projects/nvalt/) - Fork of Notational Velocity with additional features. `Free` `Open Source`
+- [SeqLog](https://seqlog.com/) - Outliner that stores every note as a plain Markdown file, with backlinks and built-in Git. `Free`
 - [The Archive](https://zettelkasten.de/the-archive/) - Note-taking app for writers and researchers. `Paid`
 - [Tot](https://tot.rocks/) - Elegant text collection on menu bar. `Freemium`
 - [Ulysses](https://ulysses.app/) - Professional writing environment for Mac. `Subscription` `EU`


### PR DESCRIPTION
Adding [SeqLog](https://seqlog.com/) to **Note-Taking & Writing**.

**Disclosure up front: I am the author.** CONTRIBUTING.md says you prefer third-party recommendations and only take a self-submission if the app is truly exceptional, so please just close this if you disagree. No hard feelings.

The reason I think it is worth a look for *this particular list*, whose premise is native and not Electron:

- Swift / SwiftUI / AppKit with a Rust core. No Electron, no web view, no bundled Chromium.
- Text rendering and scrolling go through a hand-rolled Core Text draw path with a recycling NSScrollView, not a LazyVStack. Measured on a 400-day journal: p99 frame time 8.37 ms against an 8.33 ms budget at 120 Hz, zero severe hitches.
- Notes are plain Markdown files in a folder. No database, no index. Search is ripgrep over the files.
- Backlinks, daily journal, slash commands, and an embedded Git client (libgit2) for history and sync.
- Free forever on macOS, signed and notarized, distributed outside the App Store.

Entry is alphabetical and follows the existing format. Marked `Free`, no `Open Source` tag since it is proprietary.