### PR TITLE
Add Imark to Markdown Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 - [Glance](https://glance.md/) - Native Markdown viewer and Quick Look extension. `Free`
 - [iA Writer](https://ia.net/writer) - Focused writing app with beautiful typography. `Paid`
+- [Imark](https://github.com/migsilva89/imark) - Markdown reader that stores comments inside the file, with Quick Look preview and a review loop for coding agents. `Free` `Open Source`
 - [MacDown](https://macdown.uranusjr.com/) - Open source Markdown editor for macOS. `Free` `Open Source`
 - [Marked 2](https://marked2app.com/) - Markdown preview and conversion. `Paid`
 - [MD Preview](https://vorojar.github.io/md-preview/) - Lightweight Markdown preview app using Rust and native WebView. `Free` `Open Source`


### PR DESCRIPTION
Adds [Imark](https://github.com/migsilva89/imark) to **Markdown Editors**, alphabetically between iA Writer and MacDown.

A native macOS Markdown reader. It follows the file while you edit it in another editor, previews `.md` in the Finder through a Quick Look extension, and stores comments inside the document itself as HTML comments, so a note travels with the file and stays invisible in every other renderer.

It also ships a Claude Code / Codex skill: an agent opens a document in the reader and blocks until you press Approve or Request Changes, then reads your margin notes back out of the file.

Against the app requirements:

- **Native**: Swift and AppKit, with WKWebView for document rendering only
- **Lightweight**: 13 MB, no background processes
- **Stable release**: v0.2.0, signed and notarised, macOS 14 or later
- **Open source**: MIT

One line added, nothing else touched.