### PR TITLE
Add Compact Contacts to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Alfred](https://www.alfredapp.com/) - Productivity app for macOS with powerful workflows. `Freemium`
 - [BetterTouchTool](https://folivora.ai/) - Customize input devices on your Mac. `Paid` `EU`
 - [Blurt](https://blurtblurt.com) - Hold-a-hotkey dictation that pastes cleaned-up text into any app, using AssemblyAI cloud speech-to-text. `Free` `Open Source`
+- [Compact Contacts](https://wedontneed.github.io/compact-contacts/) - Search, organize, and edit system contacts in a native table. `Paid`
 - [Due](https://www.dueapp.com/) - Reminders with persistent alerts. `Paid`
 - [Fantastical](https://flexibits.com/fantastical) - Calendar app with natural language input. `Subscription`
 - [Focus](https://heyfocus.com/) - Block distracting websites and applications. `Paid`


### PR DESCRIPTION
## What changed

- Added Compact Contacts to the Productivity section in alphabetical order.
- Linked to the official product page and used the `Paid` label.

## Why

Compact Contacts is a native macOS app for searching, organizing, and carefully editing contacts from the system Contacts database in a dense table interface.

## Disclosure

I am the developer of Compact Contacts and am submitting it transparently for maintainer review. The app is a stable Mac App Store release, built with native macOS technologies, and is actively maintained.

## Validation

- Confirmed the product link returns HTTP 200.
- Confirmed there is no existing entry or open issue/PR for Compact Contacts.
- Checked alphabetical order and Markdown formatting.
