### PR TITLE
Add Browser Cookie Bridge to Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 ## Menu Bar Apps
 
 - [Bartender](https://www.macbartender.com/) - Organize your menu bar icons. `Paid`
+- [Browser Cookie Bridge](https://cookiebridge.apoorvdarshan.com/) - Move authenticated Chromium sessions between browsers and automation tools. `Free` `Open Source`
 - [Commitments](https://commitments.pages.dev/) - Your tasks in menu bar. `Paid`
 - [DatWeatherDoe](https://github.com/inderdhir/DatWeatherDoe) - Simple menu bar weather app. `Free` `Open Source`
 - [Dozer](https://github.com/Mortennn/Dozer) - Hide menu bar icons to give your Mac a cleaner look. `Free` `Open Source`


### PR DESCRIPTION
## What changed
- Add Browser Cookie Bridge to the Menu Bar Apps category
- Mark it as free and open source

## Why
Browser Cookie Bridge is a native SwiftUI macOS menu bar app for transferring authenticated Chromium sessions between supported browsers and automation tools.

## Validation
- Confirmed the app is not already listed
- Kept the section alphabetically ordered
- Verified the website returns HTTP 200
- Ran `git diff --check`