### PR TITLE
Add Screen Break to Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [One Thing](https://sindresorhus.com/one-thing) - Put a single task in your menu bar. `Paid`
 - [OpenQuack](https://github.com/larryxiao/openquack) - Transcribes a 5-minute clip in 2.8 s — local WhisperKit dictation, noise-robust. ~8 MB native Swift. `Free` `Open Source`
 - [SaneBar](https://sanebar.com) - Privacy-first menu bar manager. Hide and organize icons. `Freemium`
+- [Screen Break](https://screen-break-mac.netlify.app/) - Menu bar break reminder with guided full-screen rests. `Free`
 - [Stargazer Bar](https://jazzyalex.github.io/stargazer-bar/) - Track one public GitHub repo's stars and release downloads from your menu bar. `Free` `Open Source`
 - [Thaw](https://github.com/stonerl/Thaw) - Powerful menu bar management tool. Fork of Ice, lower resource usage. `Free` `Open Source`
 - [TickerPad](https://tickerpad.app) - Real-time crypto prices in your macOS menu bar.  `Freemium`


### PR DESCRIPTION
## Description
Adds Screen Break, a free native macOS menu bar break reminder.

## Type of Change
- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)
**App Name:** Screen Break
**Category:** Menu Bar Apps
**Website:** https://screen-break-mac.netlify.app/
**Pricing:** Free

## Checklist
- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes
Screen Break is built with Swift/AppKit and ships as a Universal macOS app for Apple Silicon and Intel Macs.