### PR TITLE
Add Screen Break

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [One Thing](https://sindresorhus.com/one-thing) - Put a single task in your menu bar. `Paid`
 - [OpenQuack](https://github.com/larryxiao/openquack) - Transcribes a 5-minute clip in 2.8 s — local WhisperKit dictation, noise-robust. ~8 MB native Swift. `Free` `Open Source`
 - [SaneBar](https://sanebar.com) - Privacy-first menu bar manager. Hide and organize icons. `Freemium`
+- [Screen Break](https://screen-break-mac.netlify.app/) - Gentle macOS menu bar break reminder with full-screen guided rests, smart idle reset, and busy auto-defer. `Free`
 - [Stargazer Bar](https://jazzyalex.github.io/stargazer-bar/) - Track one public GitHub repo's stars and release downloads from your menu bar. `Free` `Open Source`
 - [Thaw](https://github.com/stonerl/Thaw) - Powerful menu bar management tool. Fork of Ice, lower resource usage. `Free` `Open Source`
 - [TickerPad](https://tickerpad.app) - Real-time crypto prices in your macOS menu bar.  `Freemium`


### PR DESCRIPTION
Adds Screen Break, a free native macOS menu bar break reminder.

## Description

Adds Screen Break to the Menu Bar Apps section.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** Screen Break  
**Category:** Menu Bar Apps  
**Website:** https://screen-break-mac.netlify.app/  
**Pricing:** Free  

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron)
- [x] The link works and points to the official website
- [x] The description is concise and accurate
