### PR TITLE
Add XCopy to Clipboard Managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Paste](https://pasteapp.io/) - Beautiful clipboard manager with cloud sync. `Subscription`
 - [Pesty](https://github.com/momenbasel/pesty) - Native clipboard manager with pinboards and keyboard-driven pasting. `Free` `Open Source`
 - [Unclutter](https://unclutterapp.com/) - Files, notes, and clipboard manager in one. `Paid`
+- [XCopy](https://kelvenbit.github.io/XCopy-Website/) - Clipboard history for text, images, links, and files. `Free`
 
 ## Color Pickers
 


### PR DESCRIPTION
## Description

Add XCopy to the Clipboard Managers category.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** XCopy  
**Category:** Clipboard Managers  
**Website:** https://kelvenbit.github.io/XCopy-Website/  
**Pricing:** Free  

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

XCopy is a free native macOS clipboard history app for text, images, links, and files.