### PR TITLE
Add File Island to Video & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 ## Video & Media
 
+- [File Island](https://github.com/TREAFREE/FileIsland) - Local media converter with notch-based drag-and-drop and mixed-folder batches. `Free`
 - [HandBrake](https://handbrake.fr/) - Open source video transcoder. `Free` `Open Source`
 - [IINA](https://iina.io/) - Modern media player for macOS. `Free` `Open Source`
 - [Itsytv](https://github.com/nickustinov/itsytv-macos) - The missing Apple TV remote app. `Free` `Open Source`


### PR DESCRIPTION
## Summary

Adds [File Island](https://github.com/TREAFREE/FileIsland) to Video & Media. It is a native SwiftUI/AppKit macOS utility for local media conversion, mixed-folder batches, and notch-based drag-and-drop.

## Checklist

- [x] Native SwiftUI/AppKit application
- [x] Downloadable stable macOS release
- [x] Added to the appropriate category in alphabetical order
- [x] Objective one-line description under 100 characters
- [x] Accurate `Free` pricing label
- [x] No duplicate entry
- [x] `git diff --check` passes

Disclosure: this is a maker-submitted listing.