### PR TITLE
Add Halopen to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Due](https://www.dueapp.com/) - Reminders with persistent alerts. `Paid`
 - [Fantastical](https://flexibits.com/fantastical) - Calendar app with natural language input. `Subscription`
 - [Focus](https://heyfocus.com/) - Block distracting websites and applications. `Paid`
+- [Halopen](https://halopen.com) - Hold-to-talk menu bar dictation that types verbatim into any app, with an on-device mode. `Freemium`
 - [Keyboard Maestro](https://www.keyboardmaestro.com/) - Automate applications and websites. `Paid`
 - [OmniFocus](https://www.omnigroup.com/omnifocus/) - Professional-grade task management. `Paid`
 - [Raycast](https://www.raycast.com/) - Blazingly fast extendable launcher. `Freemium`


### PR DESCRIPTION
Adds [Halopen](https://halopen.com) to Productivity, alphabetically between Focus and Keyboard Maestro.

Hold the function key, speak, and the text lands at the cursor in any Mac app. It transcribes verbatim by default rather than rewriting what you said, and ships an on-device mode where no audio leaves the machine.

**Against the App Requirements**

- **Native** — written in Swift/AppKit, runs in the menu bar. No Electron, no web wrapper.
- **Lightweight** — 10.8 MB download, Universal (Apple Silicon and Intel).
- **Available** — stable release v1.8.21, Apple Developer ID signed and Apple-notarized, macOS 14.0 Sonoma or later.
- **Maintained** — actively developed; last release today.
- **Quality** — this is the one I should be straight about: Halopen is young and does not yet have a public review base. It is stable and notarized, but if "good user reviews/reputation" is a hard gate for this list, that's a fair reason to hold the entry until it has one.

Tagged `Paid` — Halopen is a 14-day free trial (everything unlocked, no card), then $19/mo, $179/yr or $499 once. It was tagged `Freemium` when this PR was opened; the permanent free tier was retired on 2026-09-07 and the tag is corrected here.

Disclosure: I work on Halopen. Happy to reword or close this if it isn't a fit.