### PR TITLE
Add Holeberry to Menu Bar Apps & Network Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Hand Mirror](https://handmirror.app/) - One-click camera check from menu bar. `Free`
 - [Headroom](https://github.com/patwalls/headroom) - Live Claude Code session (5h) and weekly (7d) usage in your menu bar — zero network calls, reads what Claude Code already writes locally. `Free` `Open Source`
 - [Hidden Bar](https://github.com/dwarvesf/hidden) - Hide menu bar items. `Free` `Open Source`
+- [Holeberry](https://github.com/pedrovieira/Holeberry) - Monitor and control your Pi-hole instances from the menu bar. `Free` `Open Source`
 - [HomeBar for Homey Pro](https://homebar.pro) - Manage your Homey Pro smart home. `Freemium`
 - [Itsycal](https://www.mowglii.com/itsycal/) - Tiny menu bar calendar. `Free` `Open Source`
 - [Itsyhome](https://github.com/nickustinov/itsyhome-macos) - Smart home meets menu bar. `Freemium` `Open Source`
@@ -273,6 +274,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 ## Network Tools
 
+- [Holeberry](https://github.com/pedrovieira/Holeberry) - Monitor and control your Pi-hole instances from the menu bar. `Free` `Open Source`
 - [Little Snitch](https://www.obdev.at/products/littlesnitch/) - Network monitor and firewall. `Paid` `EU`
 - [Micro Snitch](https://www.obdev.at/products/microsnitch/) - Monitor camera and microphone access. `Paid` `EU`
 - [NetNewsWire](https://netnewswire.com/) - RSS reader for macOS. `Free` `Open Source`


### PR DESCRIPTION
## Description

Adds **Holeberry** to **Menu Bar Apps** and **Network Tools** — a native Swift/SwiftUI macOS menu bar app to monitor and control your Pi-hole instances, no browser tab required.

**Disclosure up front: I am the author.** CONTRIBUTING.md says you prefer third-party recommendations and only take a self-submission if the app is truly exceptional, so please just close this if you disagree. No hard feelings.

Why it fits *this particular list*, whose premise is native and not Electron:

- **100% native** — Swift 6 / SwiftUI, no Electron, no web view, no bundled runtime. Ships as a small signed DMG.
- **A real menu bar citizen** — live status icon, per-instance status dots, aggregated query/blocked-domain stats, and a countdown "timer pill" while blocking is disabled.
- **Controls Pi-hole v5 & v6 directly** — disable blocking (timed or indefinite), unblock the exact domain of the current browser tab (Safari, Chrome/Chromium, Firefox, Zen), allowlist recently-blocked domains.
- **Multi-instance** — manages up to two Pi-hole instances kept in sync, plus global keyboard shortcuts.
- **Free & open source (MIT), actively maintained** — v1.0.1 released Aug 2026; macOS 14+.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** Holeberry
**Category:** Menu Bar Apps, Network Tools
**Website:** https://github.com/pedrovieira/Holeberry
**Pricing:** Free / Open Source (MIT)

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

- Searched existing PRs (open and closed) and issues before submitting: no prior submission for Holeberry or any Pi-hole app; no duplicates.
- Self-submissions have precedent here when disclosed honestly — e.g. SeqLog (#122) and Knopo (#97) were merged.
- Placing the app in two categories mirrors existing entries that appear in more than one section (e.g. Itsycal, Fantastical).
- Note: the app is built with a free Apple ID, so it is not notarized; macOS may show a Gatekeeper warning on first launch (documented in the app's README).
- This PR was prepared by the app's author with AI assistance.
