### PR TITLE
Fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ Apps must meet ALL these criteria:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=open-saas-directory/awesome-native-macosx-apps&type=Date)](https://star-history.com/#open-saas-directory/awesome-native-macosx-apps&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=open-saas-directory/awesome-native-macosx-apps&type=Date)](https://star-history.dera.page/#open-saas-directory/awesome-native-macosx-apps&Date)
 
 ## License
 


### PR DESCRIPTION
The Star History chart in the README is currently broken and no longer renders. This PR updates the chart to use the working endpoint, restoring the stargazer history graph for this repository.