### PR TITLE
Add Loadout to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [CodeEdit](https://github.com/CodeEditApp/CodeEdit) - Native code editor for macOS. `Free` `Open Source`
 - [DevCleaner](https://github.com/vashpan/xcode-dev-cleaner) - Clean Xcode cache and derived data. `Free` `Open Source`
 - [DevUtils](https://devutils.com/) - All-in-one offline toolbox for developers (42+ tools). `Freemium`
+- [Loadout](https://loadout.migsilva.dev) - Native macOS app for managing coding assistant skills, commands, subagents, and MCP servers. `Free` `Open Source`
 - [Paw](https://paw.cloud/) - Advanced API tool for Mac. `Paid`
 - [Proxyman](https://proxyman.io/) - Native HTTP debugging proxy. `Freemium`
 - [RocketSim](https://www.rocketsim.app/) - Enhance Xcode Simulator productivity. `Freemium`


### PR DESCRIPTION
## Description

Adds [Loadout](https://loadout.migsilva.dev) to **Developer Tools**, in alphabetical order between DevUtils and Paw.

Loadout is a native macOS 15+ SwiftUI app that shows what a coding assistant actually loads — skills, slash commands, subagents, plugins and MCP servers — across Claude Code, Codex and opencode in one place. It reads the session logs to attach a real usage count to each item, so you can see which of your skills and commands are used and which never fire, and it can edit the ones you own.

Swift 6 / SwiftUI, no Electron and no web wrapper. MIT licensed, free and open source, signed and notarised, macOS 15+. Source: https://github.com/migsilva89/loadout

Nothing else in the file was touched.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** Loadout
**Category:** Developer Tools
**Website:** https://loadout.migsilva.dev
**Pricing:** `Free` `Open Source`

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

I am the developer. Happy to reword the description or move the entry to another category if you would rather place it elsewhere.
