### PR TITLE
Add TabControl to Browsers & Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 ## Browsers & Web
 
 - [Orion](https://browser.kagi.com/) - Lightweight WebKit browser with zero telemetry. `Free`
+- [TabControl](https://tabcontrol.app/) - Native Safari tab manager with session saving and tab suspension. `Paid`
 - [Zen Browser](https://zen-browser.app/) - Privacy-focused, customizable browser built on Firefox. `Free` `Open Source`
 
 ## Calendar & Time


### PR DESCRIPTION
## Summary

- Add TabControl in Browsers & Web as a paid native macOS Safari app.

## Disclosure and eligibility

I am the developer of TabControl. It is a native Swift/SafariServices macOS companion app and Safari extension—not an Electron app or web wrapper—and is available as a $3.99 one-time Mac App Store purchase.

## Validation

- `git diff --check`
- Verified the official URL returns HTTP 200.
