### PR TITLE
Add Zisla to Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Thaw](https://github.com/stonerl/Thaw) - Powerful menu bar management tool. Fork of Ice, lower resource usage. `Free` `Open Source`
 - [TickerPad](https://tickerpad.app) - Real-time crypto prices in your macOS menu bar.  `Freemium`
 - [TranslateAir](https://www.translateair.com/) - AI translation and OCR from the menu bar, 100+ languages. `Freemium`
+- [Zisla](https://github.com/wzz6423/zisla) - Native notch workspace for media, files, system tools, and local AI activity. `Free` `Open Source`
 
 ## Network Tools
 


### PR DESCRIPTION
## Description

Add Zisla to Menu Bar Apps. This is a self-submission by the project maintainer; Zisla is a MIT-licensed native Swift/SwiftUI app with a public v0.1.3 release. Please review it against the list's self-submission exception and quality criteria.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** Zisla
**Category:** Menu Bar Apps
**Website:** https://github.com/wzz6423/zisla
**Pricing:** Free / Open Source

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

Zisla is built with Swift and SwiftUI and publishes arm64, x86_64, and universal macOS artifacts for v0.1.3.
