### PR TITLE
Add FunNotch to Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Commitments](https://commitments.pages.dev/) - Your tasks in menu bar. `Paid`
 - [DatWeatherDoe](https://github.com/inderdhir/DatWeatherDoe) - Simple menu bar weather app. `Free` `Open Source`
 - [Dozer](https://github.com/Mortennn/Dozer) - Hide menu bar icons to give your Mac a cleaner look. `Free` `Open Source`
+- [FunNotch](https://github.com/JoshuaT1105/FunNotch) - Turns the MacBook notch into a media, file shelf, clipboard and focus hub. `Free` `Open Source`
 - [Hand Mirror](https://handmirror.app/) - One-click camera check from menu bar. `Free`
 - [Headroom](https://github.com/patwalls/headroom) - Live Claude Code session (5h) and weekly (7d) usage in your menu bar — zero network calls, reads what Claude Code already writes locally. `Free` `Open Source`
 - [Hidden Bar](https://github.com/dwarvesf/hidden) - Hide menu bar items. `Free` `Open Source`


### PR DESCRIPTION
Adds **FunNotch** to *Menu Bar Apps*, placed alphabetically between Dozer and Hand Mirror.

```
- [FunNotch](https://github.com/JoshuaT1105/FunNotch) - Turns the MacBook notch into a media, file shelf, clipboard and focus hub. `Free` `Open Source`
```

It fits the list's native criteria: pure Swift and SwiftUI, no Electron, no web view. AppKit `NSPanel` for the notch surface, `QLPreviewPanel` for shelf previews, `EventKit` for the calendar, `CoreAudio` for the volume HUD.

- **Source:** https://github.com/JoshuaT1105/FunNotch
- **Licence:** GPL-3.0
- **Size:** 2.7 MB, universal binary (Apple Silicon and Intel)
- **Requirements:** macOS 14+
- No account, no telemetry, no network calls except an optional GitHub check for the release version

Checked for an existing entry first; there isn't one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)