### PR TITLE
Add Belay to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 ## Developer Tools
 
+- [Belay](https://perfectoweb.github.io/Belay/en/) - Keeps a Mac awake while local coding agents are working, then lets it sleep when they're done. `Free`
 - [BucketMate](https://bucketmate.app/) - Native S3 GUI Client for macOS `Freemium`
 - [CodeEdit](https://github.com/CodeEditApp/CodeEdit) - Native code editor for macOS. `Free` `Open Source`
 - [DevCleaner](https://github.com/vashpan/xcode-dev-cleaner) - Clean Xcode cache and derived data. `Free` `Open Source`


### PR DESCRIPTION
## Description

Adds Belay, a native macOS menu bar utility that keeps the Mac awake while local coding agents are working, and lets it sleep again when they finish.

## Type of Change

- [x] Add new app

## App Details (if adding new app)

**App Name:** Belay
**Category:** Developer Tools
**Website:** https://perfectoweb.github.io/Belay/en/
**Pricing:** Free

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

Built in Swift/SwiftUI; free to use, source available at https://github.com/PerfectoWeb/Belay.
