### PR TITLE
Add Sharp Lynx to Analytics & Monitoring and Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 ## Analytics & Monitoring
 
 - [iStat Menus](https://bjango.com/mac/istatmenus/) - Advanced Mac system monitor in your menu bar. `Paid`
+- [Sharp Lynx](https://pop-hub.com/SharpLynx) - Menu bar system monitor that explains what the numbers mean — names the app behind your memory and CPU load, with temperatures, fan speed and one-press memory reclaim. `Free`
 - [Stats](https://github.com/exelban/stats) - macOS system monitor for CPU, GPU, memory, disk, and more. `Free` `Open Source`
 - [Usage](https://usage.pro) - System activity monitor for macOS, iOS, and iPadOS. `Freemium`
 
@@ -263,6 +264,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [One Thing](https://sindresorhus.com/one-thing) - Put a single task in your menu bar. `Paid`
 - [OpenQuack](https://github.com/larryxiao/openquack) - Transcribes a 5-minute clip in 2.8 s — local WhisperKit dictation, noise-robust. ~8 MB native Swift. `Free` `Open Source`
 - [SaneBar](https://sanebar.com) - Privacy-first menu bar manager. Hide and organize icons. `Freemium`
+- [Sharp Lynx](https://pop-hub.com/SharpLynx) - CPU, GPU, memory, temperatures and fan speed in your menu bar, with a dashboard that explains what macOS is doing. `Free`
 - [Stargazer Bar](https://jazzyalex.github.io/stargazer-bar/) - Track one public GitHub repo's stars and release downloads from your menu bar. `Free` `Open Source`
 - [Thaw](https://github.com/stonerl/Thaw) - Powerful menu bar management tool. Fork of Ice, lower resource usage. `Free` `Open Source`
 - [TickerPad](https://tickerpad.app) - Real-time crypto prices in your macOS menu bar.  `Freemium`


### PR DESCRIPTION
Sharp Lynx is a free menu bar system monitor for macOS, on the Mac App Store. I'm the developer.

### Why it fits the list

- **Native** — Swift and SwiftUI throughout, no Electron and no web views
- **Lightweight** — 1.8 MB, with a separate sampling process so the menu bar stays responsive and idle cost stays low
- **Actively maintained** — 6.5 shipped 2026-08-20; it started life as SystemPal in 2011 and was rewritten from scratch this year
- **Free**, on the Mac App Store, 4.5 stars from 170 ratings

### How it differs from the two already listed

iStat Menus is paid; Stats is free but distributed through GitHub/Homebrew. Sharp Lynx is free *and* on the App Store, which is the gap between them.

Beyond that, it tries to explain rather than just display. The Memory and CPU pages say what macOS is doing in plain sentences and name the app responsible — "X is using about 8.2 GB across 41 processes; quitting it should free roughly 8 GB" — and there's a one-press memory reclaim that reports what it actually recovered, including when the answer is nothing.

Temperatures and fan speed need a small free companion app, because macOS doesn't expose thermal sensors to sandboxed App Store apps. Everything else works without it.

### Entries added

Two, one per category, each inserted alphabetically. The descriptions are deliberately different rather than duplicated.

App Store: https://apps.apple.com/app/id453164367