### PR TITLE
Add Kestrel to Browsers & Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 ## Browsers & Web
 
+- [Kestrel](https://github.com/Megapixel99/kestrel) - WebKit browser that hibernates background tabs to reduce memory use. `Free` `Open Source`
 - [Orion](https://browser.kagi.com/) - Lightweight WebKit browser with zero telemetry. `Free`
 - [Zen Browser](https://zen-browser.app/) - Privacy-focused, customizable browser built on Firefox. `Free` `Open Source`
 


### PR DESCRIPTION
Adds [Kestrel](https://github.com/Megapixel99/kestrel) to **Browsers & Web**, alphabetically before Orion.

```markdown
- [Kestrel](https://github.com/Megapixel99/kestrel) - WebKit browser that hibernates background tabs to reduce memory use. `Free` `Open Source`
```

## Against the app requirements

- **Native technology**: Swift and AppKit, rendering through WKWebView. No Electron and no bundled runtime.
- **Performance**: the built bundle is 3.2 MB, well under the 200 MB guideline. Reducing memory is the point of the project rather than a side effect: background tabs are hibernated so that resident memory tracks the tab you are looking at instead of the number you have open.
- **Availability**: a universal build (arm64 and x86_64) is attached to [v0.1.0](https://github.com/Megapixel99/kestrel/releases/tag/v0.1.0), requiring macOS 13.0 or newer. MIT licensed.

## One thing worth stating plainly

The download is signed ad hoc rather than with a Developer ID, and it is not notarized, so Gatekeeper blocks it on first open until the quarantine attribute is removed. The release notes give the command and the sha256, and building from source takes about twenty seconds. If that falls short of what "downloadable and installable" means for this list, I understand closing this, and I would rather say so up front than have you find it after merging.

The measured results are in the repository ([RESULTS.md](https://github.com/Megapixel99/kestrel/blob/main/RESULTS.md)), including where the design underperformed its own prediction.