### PR TITLE
Add Sundown to System Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Pearcleaner](https://pearcleaner.com/) - Powerful Mac app cleaner `Free` `Open Source`
 - [Rectangle](https://rectangleapp.com/) - Window management with keyboard shortcuts. `Free` `Open Source`
 - [Stats](https://github.com/exelban/stats) - macOS system monitor. `Free` `Open Source`
+- [Sundown](https://trysundown.com/) - Warm and dim the display beyond Night Shift's limits on a sunset-to-sunrise schedule. `Paid` `Subscription`
 - [The Unarchiver](https://theunarchiver.com/) - Extract many archive formats. `Free`
 
 ## Terminal & Shell


### PR DESCRIPTION
## Description

Adds Sundown to System Utilities, next to the other display tools (MonitorControl, DisplayBuddy). Sundown warms and dims the Mac display beyond Night Shift's floor — Night Shift's warmest is ~2700K, Sundown goes to 500K — on a sunset-to-sunrise schedule, with gamma-curve dimming that goes darker than the backlight floor without added flicker.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** Sundown
**Category:** System Utilities
**Website:** https://trysundown.com/
**Pricing:** `Paid` `Subscription` — $4.99/mo or $39/yr subscription, or $79 one-time lifetime; 7-day free trial

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper) — 100% Swift/AppKit, ~6 MB download
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate (used both `Paid` and `Subscription` since both a one-time lifetime and subscriptions exist — happy to keep whichever one label you prefer)
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained — current release v1.4.10 (August 2026), regular updates since May 2026
- [x] No duplicate entry

## Additional Notes

Full disclosure per your guidelines: **this is my own app** — I know you prefer third-party recommendations, so treat this as a submission for your judgment rather than a neutral rec. It squarely fits the list's thesis (native Swift, no Electron, lightweight, HIG-respecting menu-bar app) and the science page (https://trysundown.com/science) cites the primary research honestly. If self-submissions are a hard no, feel free to close — no hard feelings.
