### PR TITLE
Add Grux to Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Commitments](https://commitments.pages.dev/) - Your tasks in menu bar. `Paid`
 - [DatWeatherDoe](https://github.com/inderdhir/DatWeatherDoe) - Simple menu bar weather app. `Free` `Open Source`
 - [Dozer](https://github.com/Mortennn/Dozer) - Hide menu bar icons to give your Mac a cleaner look. `Free` `Open Source`
+- [Grux](https://gruxai.com) - Reads your active window and reaches local mail, calendar, notes, and files. `Free` `Open Source`
 - [Hand Mirror](https://handmirror.app/) - One-click camera check from menu bar. `Free`
 - [Headroom](https://github.com/patwalls/headroom) - Live Claude Code session (5h) and weekly (7d) usage in your menu bar — zero network calls, reads what Claude Code already writes locally. `Free` `Open Source`
 - [Hidden Bar](https://github.com/dwarvesf/hidden) - Hide menu bar items. `Free` `Open Source`


### PR DESCRIPTION
Adds **Grux** to Menu Bar Apps, in alphabetical order between Dozer and Hand Mirror.

Grux is a menu bar assistant that reads the window you are currently in through
the Accessibility API, and reaches the mail, calendar, notes and files already on
the machine. It runs against your own API key, or against a local model with no
key at all. No account, no server, no telemetry.

- Site: https://gruxai.com
- Source: https://github.com/dotcomjack/grux

Against the App Requirements:

- **Native technology**: Swift and SwiftUI throughout, AppKit where needed. Not
  Electron, and no web view shell.
- **Performance**: the notarized build is a 21 MB download, well under the 200 MB
  guideline.
- **Availability**: stable 1.0.2 release, signed and notarized, on Apple silicon.
- **Maintenance**: actively developed, last commit today.
- **Quality**: proper macOS integration, and this is the one requirement I cannot
  claim for it. The app is new and has no user reviews yet, so I am submitting it
  on the first four criteria and leaving the fifth to your judgement.

Formatting: one line, `Free` and `Open Source` tags, no trailing whitespace.
