### PR TITLE
Add SADFinder to File Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,12 +211,13 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 ## File Management
 
 - [Commander One](https://mac.eltima.com/file-manager.html) - Dual-pane file manager for macOS. `Freemium`
+- [Encrypto](https://macpaw.com/encrypto) - Encrypt files with AES-256 encryption. `Free`
 - [ForkLift](https://binarynights.com/) - Advanced dual-pane file manager and FTP client. `Paid`
 - [Hazel](https://www.noodlesoft.com/) - Automated organization for your Mac. `Paid`
 - [NameQuick](https://www.namequick.app) - AI-powered file renaming using GPT, Gemini, or local LLMs. `Paid`
 - [Path Finder](https://www.cocoatech.io/) - Powerful Finder alternative. `Paid`
 - [Quick Look plugins](https://github.com/sindresorhus/quick-look-plugins) - Useful Quick Look plugins for developers. `Free` `Open Source`
-- [Encrypto](https://macpaw.com/encrypto) - Encrypt files with AES-256 encryption. `Free`
+- [SADFinder](https://sadfinder.com/) - Native file manager with tabs, editable paths, filtering, and keyboard-first navigation. `Paid` `EU`
 
 ## Git & Version Control
 


### PR DESCRIPTION
Adds SADFinder to the File Management section.

- Native SwiftUI macOS app for macOS 15 or later
- Downloadable from the official website and actively maintained
- Paid app developed in the EU
- Moves the existing Encrypto entry to keep the section alphabetical

Disclosure: I am the developer of SADFinder.