### PR TITLE
Add PX7 Markdown Viewer to Markdown Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Marked 2](https://marked2app.com/) - Markdown preview and conversion. `Paid`
 - [MD Preview](https://vorojar.github.io/md-preview/) - Lightweight Markdown preview app using Rust and native WebView. `Free` `Open Source`
 - [MWeb](https://www.mweb.im/) - Pro Markdown writing and note-taking. `Paid`
+- [PX7 Markdown Viewer](https://markdown.px7.digital/markdown-viewer/) - Opens and edits local Markdown files with Finder Quick Look previews. `Free` `EU`
 - [Typora](https://typora.io/) - Minimal Markdown editor and reader. `Paid`
 - [Writer](https://writer.computer/) - Local-first markdown editor with a Rust backend and native WKWebView. `Free` `Open Source`
 


### PR DESCRIPTION
## Description

Add PX7 Markdown Viewer, a free native macOS app for opening, editing, and previewing local Markdown files with Finder Quick Look.

Disclosure: I maintain this app. It is submitted because it is a focused native Swift/AppKit utility, distributed as a signed and notarized 2.1 MB download, and needs no account or paid feature.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details

**App Name:** PX7 Markdown Viewer  
**Category:** Markdown Editors  
**Website:** https://markdown.px7.digital/markdown-viewer/  
**Pricing:** Free  

## Checklist

- [x] My app follows the formatting guidelines
- [x] I have added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I have read CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry