### PR TITLE
Add Tidy to File Management and Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Path Finder](https://www.cocoatech.io/) - Powerful Finder alternative. `Paid`
 - [Quick Look plugins](https://github.com/sindresorhus/quick-look-plugins) - Useful Quick Look plugins for developers. `Free` `Open Source`
 - [Encrypto](https://macpaw.com/encrypto) - Encrypt files with AES-256 encryption. `Free`
+- [Tidy](https://tidymacapp.com) - Renames files by reading what is inside them, with on-device OCR for images and scanned PDFs, and sorts Downloads and Desktop with rules. `Paid`
 
 ## Git & Version Control
 
@@ -265,6 +266,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [SaneBar](https://sanebar.com) - Privacy-first menu bar manager. Hide and organize icons. `Freemium`
 - [Stargazer Bar](https://jazzyalex.github.io/stargazer-bar/) - Track one public GitHub repo's stars and release downloads from your menu bar. `Free` `Open Source`
 - [Thaw](https://github.com/stonerl/Thaw) - Powerful menu bar management tool. Fork of Ice, lower resource usage. `Free` `Open Source`
+- [Tidy](https://tidymacapp.com) - Names and files new downloads from the menu bar. On-device OCR, no account, no subscription. `Paid`
 - [TickerPad](https://tickerpad.app) - Real-time crypto prices in your macOS menu bar.  `Freemium`
 - [TranslateAir](https://www.translateair.com/) - AI translation and OCR from the menu bar, 100+ languages. `Freemium`
 


### PR DESCRIPTION
Tidy is a menu bar app for macOS 14 and later, written in Swift with SwiftUI and AppKit, universal binary, no Electron.

It reads what is inside images and PDFs with the local Vision OCR and renames the file after what the document actually says, then files it with rules you set. Everything runs on device: no account, no server call, no subscription. $9 once, sold from the site, not on the Mac App Store.

I am the developer. I added it to two sections, the same way Holeberry is listed in two. Happy to drop one of them or change the wording if you prefer.