### PR TITLE
Add Tomatino to Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Stargazer Bar](https://jazzyalex.github.io/stargazer-bar/) - Track one public GitHub repo's stars and release downloads from your menu bar. `Free` `Open Source`
 - [Thaw](https://github.com/stonerl/Thaw) - Powerful menu bar management tool. Fork of Ice, lower resource usage. `Free` `Open Source`
 - [TickerPad](https://tickerpad.app) - Real-time crypto prices in your macOS menu bar.  `Freemium`
+- [Tomatino](https://tomatino.app) - Pomodoro timer that switches your Focus mode and your music with each session. `Free` `Open Source`
 - [TranslateAir](https://www.translateair.com/) - AI translation and OCR from the menu bar, 100+ languages. `Freemium`
 
 ## Network Tools


### PR DESCRIPTION
Tomatino is a Pomodoro timer that lives in the macOS menu bar. Starting a session turns on a Focus mode and starts your music (Apple Music, Spotify, or a local folder it plays itself); the break turns both off again.

- Repository: https://github.com/missaq/tomatino
- Website: https://tomatino.app
- Swift and SwiftUI, AppKit for the status item. No Electron, no web wrapper, no cross-platform layer.
- Around 5 MB, no window and no Dock icon, one dependency (Sparkle for updates).
- MIT licensed, free, no account and no telemetry. Developer ID signed and notarised.
- Requires macOS 26 on Apple silicon.

Added under Menu Bar Apps in alphabetical order, between TickerPad and TranslateAir.
