### PR TITLE
Add AgentIsland to Menu Bar Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 ## Menu Bar Apps
 
+- [AgentIsland](https://agentislandapp.github.io) - Answer AI coding agents' permission prompts from the notch, without switching to the right terminal window. `Freemium`
 - [Bartender](https://www.macbartender.com/) - Organize your menu bar icons. `Paid`
 - [Commitments](https://commitments.pages.dev/) - Your tasks in menu bar. `Paid`
 - [DatWeatherDoe](https://github.com/inderdhir/DatWeatherDoe) - Simple menu bar weather app. `Free` `Open Source`


### PR DESCRIPTION
Adds AgentIsland to **Menu Bar Apps**, alphabetically first in that section.

AgentIsland is a native macOS menu bar app that surfaces AI coding agents' permission prompts (Claude Code, Gemini CLI, OpenCode and others) in the notch, so you answer them without hunting for the right terminal window. Menu Bar Apps already carries a Claude Code companion (Headroom), and this one covers the answering side rather than usage monitoring.

Against the app requirements:

- **Native** — Swift/SwiftPM, AppKit + SwiftUI, no Electron. Sparkle is the only external dependency.
- **Lightweight** — 5MB DMG.
- **Actively maintained** — 8.0.9 shipped last week.
- **Available for download** — direct DMG, Developer ID signed and notarized, or `brew install --cask agentislandapp/tap/agentisland`.
- **No malware/spyware** — no account, and no telemetry unless it is switched on, in which case Settings prints the exact field list next to the switch. Prompts, commands and repo paths never leave the machine under any setting.

Tagged `Freemium`: the free tier is permanent rather than a trial (unlimited permission, question and plan cards for one session), with a paid Pro tier.

Disclosure: I am the author.