### PR TITLE
Add FeedsBar (news ticker) to Network Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 
 ## Network Tools
 
+- [FeedsBar](https://feeds.bar/) - Always-on news ticker for the desktop with a hand-scored source catalogue. `Paid` `EU`
 - [Holeberry](https://github.com/pedrovieira/Holeberry) - Monitor and control your Pi-hole instances from the menu bar. `Free` `Open Source`
 - [Little Snitch](https://www.obdev.at/products/littlesnitch/) - Network monitor and firewall. `Paid` `EU`
 - [Micro Snitch](https://www.obdev.at/products/microsnitch/) - Monitor camera and microphone access. `Paid` `EU`


### PR DESCRIPTION
Adds FeedsBar under Network Tools, next to NetNewsWire, since the list has no news/RSS section.

- Native: Swift, SwiftUI and AppKit, no web views in the product surface.
- Lightweight: ~5 MB app; the ticker scrolls on a Core Animation layer so the main thread stays idle.
- Maintained: 1.2.7 shipped today (4 September 2026); changelog at https://feeds.bar/changelog/.
- Pricing: one-time purchase, so `Paid`. Made in Dublin, so `EU`.

Disclosure, per your guidelines: I'm the developer. If self-submissions aren't wanted here, close without ceremony and no hard feelings.