### PR TITLE
Add MacOSCleaner to utilities list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Mole](https://mole.fit/) - Clean caches, manage apps, analyze disk space, and monitor system status. `Paid`
 - [MonitorControl](https://github.com/MonitorControl/MonitorControl) - Control external display brightness and volume. `Free` `Open Source`
 - [Onyx](https://www.titanium-software.fr/en/onyx.html) - Multifunction utility for macOS. `Free` `EU`
+- [MacOSCleaner](https://github.com/AlexTkDev/MacOSCleaner) - macOS utility for cleaning caches, temporary files, app leftovers, and duplicate files. `Free` `Open Source`
 - [Pearcleaner](https://pearcleaner.com/) - Powerful Mac app cleaner `Free` `Open Source`
 - [Rectangle](https://rectangleapp.com/) - Window management with keyboard shortcuts. `Free` `Open Source`
 - [Stats](https://github.com/exelban/stats) - macOS system monitor. `Free` `Open Source`


### PR DESCRIPTION
## Description

Add MacOSCleaner to the System Utilities category.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** MacOSCleaner  
**Category:** System Utilities  
**Website:** https://github.com/AlexTkDev/MacOSCleaner  
**Pricing:** Free, Open Source

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

MacOSCleaner is a native macOS utility for cleaning caches, temporary files, app leftovers, and duplicate files.