### PR TITLE
Add SnipperApp 3 to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ curl -sL https://raw.githubusercontent.com/open-saas-directory/awesome-native-ma
 - [Proxyman](https://proxyman.io/) - Native HTTP debugging proxy. `Freemium`
 - [RocketSim](https://www.rocketsim.app/) - Enhance Xcode Simulator productivity. `Freemium`
 - [Rockxy](https://rockxy.io) - macOS HTTP/HTTPS debugging proxy to capture, inspect, modify, and replay traffic. `Freemium` `Open Source`
+- [SnipperApp 3](https://snipperapp.com) - Code snippet manager with iCloud and Gist sync, and a bundled MCP server. `Paid (one-time)`
 - [SSH Keys Manager](https://github.com/Stmol/ssh-keys-manager-macos-app) - Native macOS app for managing SSH keys and SSH config entries. `Free` `Open Source`
 - [SF Symbols](https://developer.apple.com/sf-symbols/) - Browse and export Apple's SF Symbols. `Free`
 - [Vibedock](https://vibedock.dev/) - Manage Claude Code MCP servers from your macOS menu bar. `Paid (one-time)`


### PR DESCRIPTION
## Description

SnipperApp 3 is a native macOS code snippet manager, written in Swift and SwiftUI with AppKit where it matters. No Electron, no web wrapper.

It is my own app. CONTRIBUTING says you prefer third-party recommendations, so I would rather say that plainly than let it read as one. The case for it: it ships its own Model Context Protocol server inside the app bundle, so Claude Desktop, Claude Code, Cursor and Windsurf can search, read and write the snippet library locally, with nothing leaving the Mac. Vibedock is already listed for managing MCP servers; this is a native app that is one. Happy to close this if you would rather it came from a user.

## Type of Change

- [x] Add new app
- [ ] Update existing app
- [ ] Fix broken link
- [ ] Improve description
- [ ] Other (please specify):

## App Details (if adding new app)

**App Name:** SnipperApp 3
**Category:** Developer Tools
**Website:** https://snipperapp.com
**Pricing:** Paid (one-time). $29.99 on the Mac App Store with a 7-day free trial; also on Setapp as a standalone one-time purchase.

## Checklist

- [x] My app follows the formatting guidelines
- [x] I've added the app in alphabetical order
- [x] The app is truly native (not Electron/web wrapper)
- [x] Links are working
- [x] Description is concise (< 100 characters)
- [x] Pricing label is accurate
- [x] I've read the CONTRIBUTING.md
- [x] App is actively maintained
- [x] No duplicate entry

## Additional Notes

Description is 73 characters. Placed between Rockxy and SF Symbols in Developer Tools. Pricing label copied from the Vibedock entry, which uses the same one-time model. Latest release 3.4.1, September 2026; requires macOS 15.
